### PR TITLE
fix(cd): correct checkout ref and split Vercel project IDs per branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,9 @@ jobs:
           elif [[ "$BRANCH" == "develop" && -z "${{ secrets.VERCEL_PROJECT_ID_DEV }}" ]]; then
             echo "::error::VERCEL_PROJECT_ID_DEV is required for develop branch"
             exit 1
+          elif [[ "$BRANCH" != "main" && "$BRANCH" != "develop" ]]; then
+            echo "::error::Unsupported branch for CD: $BRANCH (allowed: main, develop)"
+            exit 1
           fi
 
       - name: Checkout


### PR DESCRIPTION
## Problema
- `actions/checkout@v4` em contexto `workflow_run` sem `ref` explícito sempre fazia checkout do mesmo commit antigo (`c2e396b`), ignorando commits novos
- `VERCEL_PROJECT_ID` único deployava ambas as branches para o mesmo projeto Vercel

## Solução
- Checkout com `ref: ${{ github.event.workflow_run.head_sha || github.sha }}` — garante deploy do commit exato que passou no CI
- Project ID condicional por branch: `main` → `VERCEL_PROJECT_ID` (insidemymind-app), `develop` → `VERCEL_PROJECT_ID_DEV` (insidemymind-dev)
- Corrigido `concurrency.group` que usava `github.ref_name` (vazio em `workflow_run`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Aprimorado o gerenciamento de deploys com controle de concorrência baseado no branch de origem.
  * Ajustado o fetch para garantir que o código correto do workflow seja usado ao realizar deploy.
  * Seleção automática do projeto de implantação (produção, desenvolvimento ou vazio) conforme o branch.
  * Nova validação que impede deploys quando os identificadores de projeto necessários estiverem ausentes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->