### PR TITLE
docs: improve README — remove portfolio section, fix broken ref, humanize tone

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,23 +190,23 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 
 ## Scripts Disponíveis
 
-| Script                  | Descrição                                        |
-| ----------------------- | ------------------------------------------------ |
-| `yarn dev`              | Inicia dev server do Next.js                     |
-| `yarn build`            | Compila a aplicação para produção                |
-| `yarn start`            | Inicia o build de produção                       |
-| `yarn lint`             | Executa ESLint                                   |
-| `yarn lint:fix`         | Executa ESLint com auto-fix                      |
-| `yarn format`           | Formata todos os arquivos com Prettier           |
-| `yarn format:check`     | Verifica formatação sem escrever                 |
-| `yarn test`             | Executa testes unitários e de integração (Jest)  |
-| `yarn test:unit`        | Executa apenas testes unitários                  |
-| `yarn test:integration` | Executa apenas testes de integração              |
-| `yarn test:e2e`         | Executa testes E2E com Playwright (requer build) |
-| `yarn test:e2e:ui`      | Executa Playwright com UI interativa             |
-| `yarn test:watch`       | Executa Jest em watch mode                       |
-| `yarn test:coverage`    | Executa Jest e gera relatório de coverage        |
-| `yarn commit`           | Conventional commit interativo via Commitizen    |
+| Script                  | Descrição                                             |
+| ----------------------- | ----------------------------------------------------- |
+| `yarn dev`              | Inicia o servidor de desenvolvimento do Next.js       |
+| `yarn build`            | Compila a aplicação para produção                     |
+| `yarn start`            | Inicia a versão de produção já compilada              |
+| `yarn lint`             | Executa ESLint                                        |
+| `yarn lint:fix`         | Executa ESLint com correção automática                |
+| `yarn format`           | Formata todos os arquivos com Prettier                |
+| `yarn format:check`     | Verifica formatação sem escrever                      |
+| `yarn test`             | Executa testes unitários e de integração (Jest)       |
+| `yarn test:unit`        | Executa apenas testes unitários                       |
+| `yarn test:integration` | Executa apenas testes de integração                   |
+| `yarn test:e2e`         | Executa testes E2E com Playwright (requer compilação) |
+| `yarn test:e2e:ui`      | Executa Playwright com interface interativa           |
+| `yarn test:watch`       | Executa Jest em modo de observação                    |
+| `yarn test:coverage`    | Executa Jest e gera relatório de cobertura            |
+| `yarn commit`           | Conventional commit interativo via Commitizen         |
 
 ---
 
@@ -230,7 +230,7 @@ yarn test:coverage
 
 ### Playwright — E2E
 
-Testes completos de browser executando contra Chromium. Os testes ficam em `tests/e2e/` e rodam contra o servidor Next.js compilado.
+Testes completos de navegador executando contra Chromium. Os testes ficam em `tests/e2e/` e rodam contra o servidor Next.js compilado.
 
 ```bash
 # Build obrigatório antes de rodar em CI


### PR DESCRIPTION
## Summary

Ajustes no README traduzido após revisão:

- Removida seção "Por Que Este Projeto Importa para Seu Portfólio"
- Removida referência a `docs/architecture.pdf` (diretório não existe)
- Seção "Funcionalidades" reescrita de forma mais direta e menos verbose
- Tom geral mais natural — menos AI-generated
- Removido `---` duplicado

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentação**
  * README revisado com descrição clara do projeto como app de acompanhamento de hábitos com feedback gerado por IA e ênfase em ser open-source/educacional.
  * Seções reorganizadas: “Funcionalidades”, subseção “Agentes de IA” e resumo do Daily Lab.
  * Clarificações sobre arquitetura, uso de client/hooks de API e internacionalização (idioma da interface vs. idioma de aprendizado).
  * Tabela de scripts e notas de testes/E2E atualizadas; ajustes de formatação e limpeza geral.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->