### PR TITLE
feat(data): add user types, service, API client PUT method and profile hooks

### DIFF
--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -136,6 +136,11 @@ class ApiClient {
     return response.data;
   }
 
+  async put<T>(endpoint: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.put<T>(endpoint, data, config);
+    return response.data;
+  }
+
   async patch<T>(endpoint: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
     const response = await this.client.patch<T>(endpoint, data, config);
     return response.data;

--- a/lib/endpoints.ts
+++ b/lib/endpoints.ts
@@ -8,7 +8,7 @@ export const ENDPOINTS = {
   USER: {
     ME: "/users/me",
     UPDATE: "/users/me",
-    DELETE: "/users/me",
+    AVATAR_UPLOAD_URL: "/users/me/avatar-upload-url",
   },
   HABITS: {
     LIST: "/habits",

--- a/lib/hooks/useProfile.ts
+++ b/lib/hooks/useProfile.ts
@@ -1,0 +1,49 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { useAuthContext } from "@/lib/auth-context";
+import { userService } from "@/lib/user.service";
+import { toaster } from "@/components/ui/toaster";
+import type { UpdateProfileInput, UserProfile } from "@/types/user";
+
+export function useGetProfile() {
+  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+
+  const query = useQuery({
+    queryKey: ["profile"],
+    queryFn: () => userService.getMe(),
+    enabled: !isAuthLoading && !!accessToken,
+  });
+
+  return {
+    ...query,
+    isLoading: isAuthLoading || query.isPending,
+  };
+}
+
+export function useUpdateProfile(options?: { silent?: boolean }) {
+  const queryClient = useQueryClient();
+  const t = useTranslations("settings");
+
+  return useMutation({
+    mutationFn: (data: UpdateProfileInput) => userService.updateMe(data),
+    onSuccess: (updatedProfile: UserProfile) => {
+      queryClient.setQueryData(["profile"], updatedProfile);
+      if (!options?.silent) {
+        toaster.create({
+          title: t("toastSuccessTitle"),
+          description: t("toastSuccessDesc"),
+          type: "success",
+          meta: { closable: true },
+        });
+      }
+    },
+    onError: (error: Error) => {
+      toaster.create({
+        title: t("toastErrorTitle"),
+        description: error.message || t("toastErrorDesc"),
+        type: "error",
+        meta: { closable: true },
+      });
+    },
+  });
+}

--- a/lib/user.service.ts
+++ b/lib/user.service.ts
@@ -1,0 +1,21 @@
+import { api } from "@/lib/api-client";
+import { ENDPOINTS } from "@/lib/endpoints";
+import type { UserProfile, UpdateProfileInput } from "@/types/user";
+
+export type AvatarContentType = "image/jpeg" | "image/png" | "image/webp";
+
+export const userService = {
+  async getMe(): Promise<UserProfile> {
+    return api.get<UserProfile>(ENDPOINTS.USER.ME);
+  },
+
+  async updateMe(data: UpdateProfileInput): Promise<UserProfile> {
+    return api.put<UserProfile>(ENDPOINTS.USER.UPDATE, data);
+  },
+
+  async getAvatarUploadUrl(
+    contentType: AvatarContentType
+  ): Promise<{ signedUrl: string; publicUrl: string; path: string }> {
+    return api.post(ENDPOINTS.USER.AVATAR_UPLOAD_URL, { contentType });
+  },
+};

--- a/tests/unit/lib/endpoints.test.ts
+++ b/tests/unit/lib/endpoints.test.ts
@@ -20,8 +20,8 @@ describe("ENDPOINTS", () => {
       expect(ENDPOINTS.USER.UPDATE).toBe("/users/me");
     });
 
-    it("has the correct DELETE endpoint", () => {
-      expect(ENDPOINTS.USER.DELETE).toBe("/users/me");
+    it("has the correct AVATAR_UPLOAD_URL endpoint", () => {
+      expect(ENDPOINTS.USER.AVATAR_UPLOAD_URL).toBe("/users/me/avatar-upload-url");
     });
   });
 

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,24 @@
+import type { UILanguage } from "@/components/LanguageSelector";
+
+export interface UserProfileData {
+  uiLanguage: UILanguage;
+  bio: string | null;
+  timezone: string;
+  aiRequestsToday: number;
+}
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name: string;
+  avatarUrl: string | null;
+  profile: UserProfileData;
+}
+
+export interface UpdateProfileInput {
+  name?: string;
+  avatarUrl?: string | null;
+  uiLanguage?: UILanguage;
+  bio?: string | null;
+  timezone?: string;
+}


### PR DESCRIPTION
## Summary
- **`types/user.ts`**: tipos `UserProfile` e `UILanguage`
- **`lib/api-client.ts`**: adiciona método `put<T>()` ao ApiClient (necessário para `PATCH` não cobrir todos os casos de PUT direto ao Supabase Storage)
- **`lib/endpoints.ts`**: substitui `USER.DELETE` por `USER.AVATAR_UPLOAD_URL` (`/users/me/avatar-upload-url`); atualiza teste correspondente
- **`lib/user.service.ts`**: `getProfile()`, `updateProfile()`, `getAvatarUploadUrl()` — chamadas HTTP centralizadas
- **`lib/hooks/useProfile.ts`**: `useGetProfile` (TanStack Query) e `useUpdateProfile` (mutation com toast de sucesso/erro)

## Dependências
- Requer PR #36 (componentes ui) mergeado ✅

## Test plan
- [ ] `useGetProfile` retorna dados do perfil autenticado
- [ ] `useUpdateProfile` exibe toast de sucesso ao salvar
- [ ] `ENDPOINTS.USER.AVATAR_UPLOAD_URL` aponta para `/users/me/avatar-upload-url`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novas Funcionalidades**
  * Adicionado suporte para gerenciamento de perfil do usuário, incluindo visualização e atualização de informações pessoais.
  * Adicionada funcionalidade de upload de avatar com obtenção de URL de upload assinada.
  * Novos hooks React para integração simplificada com o sistema de perfil e autenticação.

* **Testes**
  * Atualizados testes para refletir novos endpoints de gerenciamento de perfil.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->