### PR TITLE
feat: add habits domain types, service and React Query hooks

### DIFF
--- a/lib/habit.service.ts
+++ b/lib/habit.service.ts
@@ -1,0 +1,169 @@
+import { api } from "@/lib/api-client";
+import { ENDPOINTS } from "@/lib/endpoints";
+import type { Habit, HabitMode, HabitPlan, PlanStatus, TargetSkill } from "@/types/habits";
+import { LANGUAGE_SKILLS } from "@/types/habits";
+
+export interface ApiHabit {
+  id: string;
+  userId: string;
+  name: string;
+  targetSkill: string | null;
+  icon: string;
+  color: string;
+  frequency: string;
+  targetDays: number;
+  isActive: boolean;
+  sortOrder: number;
+  startDate: string | null;
+  habitPlan: Record<string, unknown>;
+  planStatus: string;
+  streak: number;
+  currentDay: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface HabitLogInput {
+  logDate: string;
+  completed: boolean;
+}
+
+export interface HabitLogResponse {
+  id: string;
+  habitId: string;
+  logDate: string;
+  completed: boolean;
+  completedAt: string | null;
+}
+
+const VALID_SKILLS = new Set<TargetSkill>([
+  "en-US",
+  "es-ES",
+  "pt-BR",
+  "general",
+  "fitness",
+  "mindfulness",
+]);
+
+function toTargetSkill(apiSkill: string | null): TargetSkill {
+  if (apiSkill && VALID_SKILLS.has(apiSkill as TargetSkill)) {
+    return apiSkill as TargetSkill;
+  }
+  return "general";
+}
+
+function toHabitMode(targetSkill: TargetSkill): HabitMode {
+  return LANGUAGE_SKILLS.includes(targetSkill) ? "skill-building" : "tracking-coached";
+}
+
+function toPlanStatus(apiStatus: string, habitPlan: Record<string, unknown>): PlanStatus {
+  switch (apiStatus) {
+    case "generating":
+      return "generating";
+    case "failed":
+      return "failed";
+    case "pending":
+      return "pending";
+    case "ready":
+      return "ready";
+    case "active":
+      return Object.keys(habitPlan).length > 0 ? "ready" : "skipped";
+    default:
+      return "skipped";
+  }
+}
+
+function toChakraColor(apiColor: string): string {
+  // "bg-surface-mint" → "surface.mint"
+  return apiColor.replace(/^bg-/, "").replace(/-([^-]+)$/, ".$1");
+}
+
+function toHabitPlan(raw: Record<string, unknown>): HabitPlan | null {
+  if (!raw || !raw.strategy || !Array.isArray(raw.phases)) return null;
+  return raw as unknown as HabitPlan;
+}
+
+export function mapApiHabitToHabit(apiHabit: ApiHabit): Habit {
+  const targetSkill = toTargetSkill(apiHabit.targetSkill);
+  return {
+    id: apiHabit.id,
+    name: apiHabit.name,
+    target_skill: targetSkill,
+    habit_mode: toHabitMode(targetSkill),
+    icon: apiHabit.icon,
+    color: toChakraColor(apiHabit.color),
+    frequency: apiHabit.frequency,
+    is_active: apiHabit.isActive,
+    start_date: apiHabit.startDate ?? "",
+    current_day: apiHabit.currentDay ?? 1,
+    streak: apiHabit.streak ?? 0,
+    plan_status: toPlanStatus(apiHabit.planStatus, apiHabit.habitPlan),
+    habit_plan: toHabitPlan(apiHabit.habitPlan),
+  };
+}
+
+export interface CreateHabitInput {
+  name: string;
+  icon: string;
+  color: string;
+  targetSkill?: string;
+  frequency?: string;
+  sortOrder?: number;
+  startDate?: string;
+  habitPlan?: HabitPlan;
+}
+
+export interface PreviewPlanInput {
+  name: string;
+  targetSkill?: string;
+  painPoints: string[];
+  availableMinutes: number;
+  level: "beginner" | "intermediate" | "advanced";
+}
+
+export interface CreateWithPlanInput extends CreateHabitInput {
+  painPoints: string[];
+  availableMinutes: number;
+  level: "beginner" | "intermediate" | "advanced";
+}
+
+export interface RegeneratePlanInput {
+  painPoints: string[];
+  availableMinutes: number;
+  level: "beginner" | "intermediate" | "advanced";
+}
+
+export const habitService = {
+  async list(): Promise<Habit[]> {
+    const data = await api.get<ApiHabit[]>(ENDPOINTS.HABITS.LIST);
+    return data.map(mapApiHabitToHabit);
+  },
+
+  async getById(id: string): Promise<Habit> {
+    const data = await api.get<ApiHabit>(ENDPOINTS.HABITS.GET(id));
+    return mapApiHabitToHabit(data);
+  },
+
+  async create(input: CreateHabitInput): Promise<Habit> {
+    const data = await api.post<ApiHabit>(ENDPOINTS.HABITS.CREATE, input);
+    return mapApiHabitToHabit(data);
+  },
+
+  async previewPlan(input: PreviewPlanInput): Promise<HabitPlan> {
+    return api.post<HabitPlan>(ENDPOINTS.HABITS.PREVIEW_PLAN, input);
+  },
+
+  async createWithPlan(input: CreateWithPlanInput): Promise<Habit> {
+    const data = await api.post<ApiHabit>(ENDPOINTS.HABITS.CREATE_WITH_PLAN, input);
+    return mapApiHabitToHabit(data);
+  },
+
+  async regeneratePlan(id: string, input: RegeneratePlanInput): Promise<Habit> {
+    const data = await api.post<ApiHabit>(ENDPOINTS.HABITS.REGENERATE_PLAN(id), input);
+    return mapApiHabitToHabit(data);
+  },
+
+  async log(id: string, input: HabitLogInput): Promise<HabitLogResponse> {
+    return api.post<HabitLogResponse>(ENDPOINTS.HABITS.LOG(id), input);
+  },
+};

--- a/lib/hooks/useHabits.ts
+++ b/lib/hooks/useHabits.ts
@@ -1,0 +1,35 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuthContext } from "@/lib/auth-context";
+import { habitService, type CreateHabitInput, type PreviewPlanInput } from "@/lib/habit.service";
+import type { Habit } from "@/types/habits";
+
+export function useHabits() {
+  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+
+  const query = useQuery<Habit[], Error>({
+    queryKey: ["habits"],
+    queryFn: () => habitService.list(),
+    enabled: !isAuthLoading && !!accessToken,
+  });
+
+  return {
+    ...query,
+    isLoading: isAuthLoading || query.isPending,
+  };
+}
+
+export function usePreviewHabitPlan() {
+  return useMutation({
+    mutationFn: (input: PreviewPlanInput) => habitService.previewPlan(input),
+  });
+}
+
+export function useCreateHabit() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateHabitInput) => habitService.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["habits"] });
+    },
+  });
+}

--- a/types/habits.ts
+++ b/types/habits.ts
@@ -1,0 +1,127 @@
+// target_skill uses architecture codes directly — matches imm-api values
+export type TargetSkill = "en-US" | "es-ES" | "pt-BR" | "general" | "fitness" | "mindfulness";
+
+export type HabitMode = "skill-building" | "tracking-coached";
+
+export type PlanStatus = "ready" | "generating" | "pending" | "failed" | "skipped";
+
+export interface HabitPlanPhase {
+  phase: number;
+  days: string;
+  theme: string;
+}
+
+export interface SkillBuildingPhase extends HabitPlanPhase {
+  daily_tasks: string[];
+}
+
+export interface TrackingCoachedPhase extends HabitPlanPhase {
+  weekly_focus: string;
+  tip: string;
+}
+
+export interface HabitPlan {
+  strategy: string;
+  total_time_per_day_minutes: number;
+  success_metrics: string;
+  phases: (SkillBuildingPhase | TrackingCoachedPhase)[];
+}
+
+export interface Habit {
+  id: string;
+  name: string;
+  target_skill: TargetSkill;
+  habit_mode: HabitMode;
+  icon: string;
+  color: string;
+  frequency: string;
+  is_active: boolean;
+  start_date: string;
+  current_day: number;
+  streak: number;
+  plan_status: PlanStatus;
+  habit_plan: HabitPlan | null;
+}
+
+// Language skills → Language Teacher agent (skill-building)
+export const LANGUAGE_SKILLS: TargetSkill[] = ["en-US", "es-ES", "pt-BR"];
+
+// Behavioral skills → Behavioral Coach agent (tracking-coached)
+export const BEHAVIORAL_SKILLS: TargetSkill[] = ["general", "fitness", "mindfulness"];
+
+export const SKILL_ICONS: Record<TargetSkill, string> = {
+  "en-US": "🇺🇸",
+  "es-ES": "🇪🇸",
+  "pt-BR": "🇧🇷",
+  general: "🧠",
+  fitness: "💪",
+  mindfulness: "🧘",
+};
+
+// Skill metadata for UI display
+export type SkillMetadata = {
+  label: string; // Translation key
+  icon: string;
+  shortDescription: string; // Translation key: short 1-line description
+  longDescription?: string; // Translation key: longer explanation for tooltip/modal
+  category: "language" | "behavioral";
+  hasDailyPlan: boolean; // skill-building has detailed daily tasks
+};
+
+export const SKILL_METADATA: Record<TargetSkill, SkillMetadata> = {
+  "en-US": {
+    label: "habits.skills.en-US.name",
+    icon: "🇺🇸",
+    shortDescription: "habits.skills.en-US.short",
+    longDescription: "habits.skills.en-US.long",
+    category: "language",
+    hasDailyPlan: true,
+  },
+  "es-ES": {
+    label: "habits.skills.es-ES.name",
+    icon: "🇪🇸",
+    shortDescription: "habits.skills.es-ES.short",
+    longDescription: "habits.skills.es-ES.long",
+    category: "language",
+    hasDailyPlan: true,
+  },
+  "pt-BR": {
+    label: "habits.skills.pt-BR.name",
+    icon: "🇧🇷",
+    shortDescription: "habits.skills.pt-BR.short",
+    longDescription: "habits.skills.pt-BR.long",
+    category: "language",
+    hasDailyPlan: true,
+  },
+  general: {
+    label: "habits.skills.general.name",
+    icon: "🧠",
+    shortDescription: "habits.skills.general.short",
+    longDescription: "habits.skills.general.long",
+    category: "behavioral",
+    hasDailyPlan: false,
+  },
+  fitness: {
+    label: "habits.skills.fitness.name",
+    icon: "💪",
+    shortDescription: "habits.skills.fitness.short",
+    longDescription: "habits.skills.fitness.long",
+    category: "behavioral",
+    hasDailyPlan: false,
+  },
+  mindfulness: {
+    label: "habits.skills.mindfulness.name",
+    icon: "🧘",
+    shortDescription: "habits.skills.mindfulness.short",
+    longDescription: "habits.skills.mindfulness.long",
+    category: "behavioral",
+    hasDailyPlan: false,
+  },
+};
+
+export function deriveHabitMode(skill: TargetSkill): HabitMode {
+  return LANGUAGE_SKILLS.includes(skill) ? "skill-building" : "tracking-coached";
+}
+
+export const MAX_ACTIVE_HABITS = 5;
+export const WARN_ACTIVE_HABITS = 3;


### PR DESCRIPTION
## Summary

- `types/habits.ts` — define `Habit`, `HabitPlan`, `TargetSkill`, `HabitMode`, `PlanStatus` e constantes de threshold
- `lib/habit.service.ts` — camada de serviço com integração à API e funções de mapeamento (`toChakraColor`, `toPlanStatus`, etc.)
- `lib/hooks/useHabits.ts` — hooks React Query: `useHabits`, `usePreviewHabitPlan` e `useCreateHabit`

## Dependências

Depende do PR #41 (endpoints de habits) — já mergeado em `develop`.

## Test plan

- [ ] Tipos compilam sem erros (`yarn tsc --noEmit`)
- [ ] `useHabits` busca habits corretamente com cache auth-aware
- [ ] `useCreateHabit` invalida o cache após criação bem-sucedida