### PR TITLE
feat: implement multi-step habit creation wizard

### DIFF
--- a/components/habits/HabitCreationWizard.styles.ts
+++ b/components/habits/HabitCreationWizard.styles.ts
@@ -1,0 +1,194 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  formStack: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 5,
+  },
+
+  label: {
+    display: "block",
+    fontSize: "sm",
+    fontWeight: "bold",
+    textTransform: "uppercase",
+    letterSpacing: "wider",
+    mb: 2,
+  },
+
+  input: {
+    bg: "white",
+    border: "2px solid black",
+    borderRadius: "0",
+    _focus: { ring: "2px", ringColor: "ring" },
+  },
+
+  textarea: {
+    bg: "white",
+    border: "2px solid black",
+    borderRadius: "0",
+    resize: "none",
+    _focus: { ring: "2px", ringColor: "ring" },
+  },
+
+  sectionLabel: {
+    fontSize: "xs",
+    fontWeight: "bold",
+    textTransform: "uppercase",
+    mb: 2,
+    color: "mutedFg",
+  },
+
+  modeHintSkill: {
+    border: "3px solid black",
+    bg: "surface.mint",
+    p: 3,
+  },
+
+  modeHintTracking: {
+    border: "3px solid black",
+    bg: "surface.lavender",
+    p: 3,
+  },
+
+  modeHintText: {
+    fontSize: "sm",
+    fontWeight: "bold",
+  },
+
+  planNoteSkill: {
+    bg: "surface.mint",
+    border: "3px solid black",
+    p: 3,
+  },
+
+  planNoteTracking: {
+    bg: "surface.lavender",
+    border: "3px solid black",
+    p: 3,
+  },
+
+  planNoteText: {
+    fontSize: "sm",
+    fontWeight: "bold",
+  },
+
+  toggleRow: {
+    border: "3px solid black",
+    bg: "card",
+    p: 4,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+
+  toggleLabel: {
+    fontWeight: "bold",
+  },
+
+  manualNote: {
+    bg: "muted",
+    border: "3px solid black",
+    p: 4,
+  },
+
+  manualNoteText: {
+    fontSize: "sm",
+    fontWeight: "bold",
+  },
+
+  summaryCard: {
+    border: "3px solid black",
+    bg: "card",
+    p: 4,
+  },
+
+  summaryTitle: {
+    fontWeight: "800",
+    mb: 3,
+    textTransform: "uppercase",
+  },
+
+  summaryStack: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    fontSize: "sm",
+    fontWeight: "500",
+  },
+
+  planPreview: {
+    border: "3px solid black",
+    bg: "card",
+    p: 4,
+    display: "flex",
+    flexDirection: "column",
+    gap: 3,
+  },
+
+  planPreviewTitle: {
+    fontWeight: "800",
+    textTransform: "uppercase",
+    fontSize: "sm",
+    mb: 1,
+  },
+
+  planStrategy: {
+    fontSize: "sm",
+    fontWeight: "500",
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+  },
+
+  phaseCard: {
+    border: "2px solid black",
+    bg: "muted",
+    p: 3,
+  },
+
+  phaseHeader: {
+    fontSize: "xs",
+    fontWeight: "bold",
+    textTransform: "uppercase",
+    color: "mutedFg",
+    mb: 1,
+  },
+
+  phaseTitle: {
+    fontWeight: "700",
+    fontSize: "sm",
+    mb: 2,
+  },
+
+  taskList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+  },
+
+  taskItem: {
+    fontSize: "sm",
+    fontWeight: "500",
+  },
+
+  loadingContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 4,
+    py: 8,
+    textAlign: "center",
+  },
+
+  loadingTitle: {
+    fontWeight: "800",
+    textTransform: "uppercase",
+  },
+
+  loadingSubtitle: {
+    fontSize: "sm",
+    fontWeight: "500",
+    color: "mutedFg",
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/components/habits/HabitCreationWizard.tsx
+++ b/components/habits/HabitCreationWizard.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState } from "react";
+import { Box, HStack } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui/button";
+import { type TargetSkill, type HabitPlan, SKILL_ICONS, deriveHabitMode } from "@/types/habits";
+import { usePreviewHabitPlan, useCreateHabit } from "@/lib/hooks/useHabits";
+import { type PreviewPlanInput } from "@/lib/habit.service";
+import { HabitSetupForm } from "./wizard/HabitSetupForm";
+import { SkillPlanForm } from "./wizard/SkillPlanForm";
+import { TrackingOptionsForm } from "./wizard/TrackingOptionsForm";
+import { PlanReviewPanel } from "./wizard/PlanReviewPanel";
+import {
+  WIZARD_FORM_ID,
+  type Step1Data,
+  type Step2SkillData,
+  type Step2TrackingData,
+} from "./wizard/types";
+
+const API_COLORS = [
+  "bg-surface-mint",
+  "bg-surface-sky",
+  "bg-surface-coral",
+  "bg-surface-lavender",
+  "bg-surface-yellow",
+];
+
+interface HabitCreationWizardProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function HabitCreationWizard({ open, onClose, onCreated }: HabitCreationWizardProps) {
+  const t = useTranslations("habitWizard");
+  const tStep1 = useTranslations("habitWizard.step1");
+  const tStep2Skill = useTranslations("habitWizard.step2Skill");
+  const tStep2Track = useTranslations("habitWizard.step2Tracking");
+  const tStep3 = useTranslations("habitWizard.step3");
+
+  const [step, setStep] = useState(1);
+  const [step1Data, setStep1Data] = useState<Step1Data | null>(null);
+  const [step2Data, setStep2Data] = useState<Step2SkillData | Step2TrackingData | null>(null);
+  const [previewedPlan, setPreviewedPlan] = useState<HabitPlan | null>(null);
+  const [stepError, setStepError] = useState<"generic" | "rate-limit" | null>(null);
+
+  const previewMutation = usePreviewHabitPlan();
+  const createMutation = useCreateHabit();
+
+  const mode = step1Data ? deriveHabitMode(step1Data.targetSkill as TargetSkill) : null;
+  const wantPlan = (step2Data as Step2TrackingData)?.wantPlan ?? false;
+  const needsPlan = mode === "skill-building" || wantPlan;
+  const randomColor = () => API_COLORS[Math.floor(Math.random() * API_COLORS.length)];
+
+  const buildPainPoints = (data: Step2SkillData | Step2TrackingData): string[] => {
+    const raw = (data as Step2TrackingData).barrier || (data as Step2SkillData).struggles;
+    const parts = raw
+      .split(/[.,;]+/)
+      .map((s: string) => s.trim())
+      .filter(Boolean);
+    return parts.length > 0 ? parts : [raw];
+  };
+
+  const handleStep1Next = (data: Step1Data) => {
+    setStep1Data(data);
+    setStep(2);
+  };
+
+  const handleStep2Next = async (data: Step2SkillData | Step2TrackingData) => {
+    setStep2Data(data);
+    setStepError(null);
+    setStep(3);
+
+    const localNeedsPlan = mode === "skill-building" || (data as Step2TrackingData).wantPlan;
+    if (!localNeedsPlan || !step1Data) return;
+
+    const previewInput: PreviewPlanInput = {
+      name: step1Data.name,
+      targetSkill: step1Data.targetSkill,
+      painPoints: buildPainPoints(data),
+      availableMinutes: data.availableMinutes,
+      level: data.level,
+    };
+
+    try {
+      const plan = await previewMutation.mutateAsync(previewInput);
+      setPreviewedPlan(plan);
+    } catch (err) {
+      setStepError(err instanceof Error && err.message.includes("429") ? "rate-limit" : "generic");
+    }
+  };
+
+  const handleRegenerate = async () => {
+    if (!step1Data || !step2Data) return;
+    setStepError(null);
+
+    const previewInput: PreviewPlanInput = {
+      name: step1Data.name,
+      targetSkill: step1Data.targetSkill,
+      painPoints: buildPainPoints(step2Data),
+      availableMinutes: step2Data.availableMinutes,
+      level: step2Data.level,
+    };
+
+    try {
+      const plan = await previewMutation.mutateAsync(previewInput);
+      setPreviewedPlan(plan);
+    } catch (err) {
+      setStepError(err instanceof Error && err.message.includes("429") ? "rate-limit" : "generic");
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!step1Data) return;
+    await createMutation.mutateAsync({
+      name: step1Data.name,
+      icon: SKILL_ICONS[step1Data.targetSkill as TargetSkill],
+      color: randomColor(),
+      targetSkill: step1Data.targetSkill,
+      frequency: "daily",
+      ...(previewedPlan ? { habitPlan: previewedPlan } : {}),
+    });
+    onCreated();
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setStep(1);
+    setStep1Data(null);
+    setStep2Data(null);
+    setPreviewedPlan(null);
+    setStepError(null);
+    previewMutation.reset();
+    createMutation.reset();
+    onClose();
+  };
+
+  const goBack = () => {
+    setStepError(null);
+    setPreviewedPlan(null);
+    previewMutation.reset();
+    setStep((s) => s - 1);
+  };
+
+  const isPreviewLoading = previewMutation.isPending;
+  const isConfirming = createMutation.isPending;
+  const isDisabled = isPreviewLoading || isConfirming;
+
+  const footer = (() => {
+    if (step === 1) {
+      return (
+        <Button type="submit" form={WIZARD_FORM_ID} variant="primary" w="100%">
+          {tStep1("next")}
+        </Button>
+      );
+    }
+
+    if (step === 2) {
+      const label =
+        mode === "skill-building"
+          ? tStep2Skill("generate")
+          : wantPlan
+            ? tStep2Track("nextWithPlan")
+            : tStep2Track("next");
+      return (
+        <Box display="flex" flexDirection="column" gap={2} w="100%">
+          <Button
+            type="submit"
+            form={WIZARD_FORM_ID}
+            variant="primary"
+            w="100%"
+            loading={isPreviewLoading}
+          >
+            {label}
+          </Button>
+          <Button type="button" variant="muted" w="100%" onClick={goBack}>
+            {tStep2Skill("back")}
+          </Button>
+        </Box>
+      );
+    }
+
+    if (step === 3 && stepError !== null) {
+      return (
+        <Button type="button" variant="muted" w="100%" onClick={goBack}>
+          {tStep3("back")}
+        </Button>
+      );
+    }
+
+    if (step === 3) {
+      return (
+        <Box display="flex" flexDirection="column" gap={2} w="100%">
+          <HStack gap={2}>
+            <Button type="button" variant="muted" flex={1} onClick={goBack} disabled={isDisabled}>
+              {tStep3("back")}
+            </Button>
+            {needsPlan && (
+              <Button
+                type="button"
+                variant="muted"
+                flex={1}
+                onClick={handleRegenerate}
+                disabled={isDisabled}
+                loading={isPreviewLoading}
+              >
+                {tStep3("regenerate")}
+              </Button>
+            )}
+          </HStack>
+          <Button
+            type="button"
+            variant="primary"
+            w="100%"
+            onClick={handleConfirm}
+            disabled={isDisabled}
+            loading={isConfirming}
+          >
+            {tStep3("create")}
+          </Button>
+        </Box>
+      );
+    }
+
+    return null;
+  })();
+
+  return (
+    <Modal open={open} onClose={handleClose} title={t("title")} footer={footer} maxW="680px">
+      <HStack gap={2} mb={6}>
+        {[1, 2, 3].map((n) => (
+          <Box
+            key={n}
+            flex={1}
+            h={2}
+            bg={step >= n ? "primary" : "muted"}
+            border="2px solid black"
+          />
+        ))}
+      </HStack>
+
+      {step === 1 && (
+        <HabitSetupForm defaultValues={step1Data ?? undefined} onNext={handleStep1Next} />
+      )}
+
+      {step === 2 && mode === "skill-building" && (
+        <SkillPlanForm
+          defaultValues={(step2Data as Step2SkillData) ?? undefined}
+          onNext={handleStep2Next}
+        />
+      )}
+
+      {step === 2 && mode === "tracking-coached" && (
+        <TrackingOptionsForm
+          defaultValues={(step2Data as Step2TrackingData) ?? undefined}
+          onNext={handleStep2Next}
+        />
+      )}
+
+      {step === 3 && step1Data && (
+        <PlanReviewPanel
+          habitName={step1Data.name}
+          habitIcon={SKILL_ICONS[step1Data.targetSkill as TargetSkill]}
+          habitTargetSkill={step1Data.targetSkill as TargetSkill}
+          wantPlan={wantPlan}
+          previewedPlan={previewedPlan}
+          isLoading={isPreviewLoading}
+        />
+      )}
+
+      {step === 3 && stepError !== null && (
+        <Box border="3px solid black" bg="surface.coral" p={4} mt={4}>
+          <strong>{tStep3(stepError === "rate-limit" ? "rateLimitTitle" : "errorTitle")}</strong>
+          <br />
+          <span style={{ fontSize: "0.875rem" }}>
+            {tStep3(stepError === "rate-limit" ? "rateLimitSubtitle" : "errorSubtitle")}
+          </span>
+        </Box>
+      )}
+    </Modal>
+  );
+}

--- a/components/habits/wizard/HabitSetupForm.tsx
+++ b/components/habits/wizard/HabitSetupForm.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Box, Grid, Input, Text, VStack } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import {
+  type TargetSkill,
+  LANGUAGE_SKILLS,
+  BEHAVIORAL_SKILLS,
+  deriveHabitMode,
+} from "@/types/habits";
+import { SkillCard } from "./SkillCard";
+import { s } from "../HabitCreationWizard.styles";
+import { step1Schema, type Step1Data, WIZARD_FORM_ID } from "./types";
+
+interface Step1FormProps {
+  defaultValues?: Partial<Step1Data>;
+  onNext: (_data: Step1Data) => void;
+}
+
+export function HabitSetupForm({ defaultValues, onNext }: Step1FormProps) {
+  const t = useTranslations("habitWizard.step1");
+
+  const { control, handleSubmit, watch } = useForm<Step1Data>({
+    resolver: zodResolver(step1Schema),
+    defaultValues: { name: "", targetSkill: "", ...defaultValues },
+  });
+
+  const targetSkill = watch("targetSkill") as TargetSkill | "";
+  const mode = targetSkill ? deriveHabitMode(targetSkill as TargetSkill) : null;
+
+  return (
+    <Box as="form" id={WIZARD_FORM_ID} onSubmit={handleSubmit(onNext)}>
+      <Box {...s.formStack}>
+        <Box>
+          <Text as="label" {...s.label}>
+            {t("habitNameLabel")}
+          </Text>
+          <Controller
+            name="name"
+            control={control}
+            render={({ field }) => (
+              <Input {...field} placeholder={t("habitNamePlaceholder")} {...s.input} />
+            )}
+          />
+        </Box>
+
+        <Box>
+          <Text as="label" {...s.label}>
+            {t("targetSkillLabel")}
+          </Text>
+          <Controller
+            name="targetSkill"
+            control={control}
+            render={({ field }) => (
+              <VStack gap={6} align="stretch">
+                {/* Language Skills Section */}
+                <Box>
+                  <Text {...s.sectionLabel}>{t("langSkillsLabel")}</Text>
+                  <Text fontSize="xs" color="text.muted" mb={3}>
+                    {t("langSkillsHint")}
+                  </Text>
+                  <Grid templateColumns="repeat(auto-fit, minmax(240px, 1fr))" gap={3}>
+                    {LANGUAGE_SKILLS.map((skill) => (
+                      <SkillCard
+                        key={skill}
+                        skill={skill}
+                        isSelected={field.value === skill}
+                        onClick={() => field.onChange(skill)}
+                      />
+                    ))}
+                  </Grid>
+                </Box>
+
+                {/* Behavioral Skills Section */}
+                <Box>
+                  <Text {...s.sectionLabel}>{t("behaviorLabel")}</Text>
+                  <Text fontSize="xs" color="text.muted" mb={3}>
+                    {t("behaviorHint")}
+                  </Text>
+                  <Grid templateColumns="repeat(auto-fit, minmax(240px, 1fr))" gap={3}>
+                    {BEHAVIORAL_SKILLS.map((skill) => (
+                      <SkillCard
+                        key={skill}
+                        skill={skill}
+                        isSelected={field.value === skill}
+                        onClick={() => field.onChange(skill)}
+                      />
+                    ))}
+                  </Grid>
+                </Box>
+              </VStack>
+            )}
+          />
+        </Box>
+
+        {targetSkill && mode && (
+          <Box {...(mode === "skill-building" ? s.modeHintSkill : s.modeHintTracking)}>
+            <Text {...s.modeHintText}>
+              {mode === "skill-building" ? t("modeHintSkill") : t("modeHintTracking")}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/habits/wizard/PlanReviewPanel.tsx
+++ b/components/habits/wizard/PlanReviewPanel.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Box, Heading, Spinner, Text } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import {
+  type TargetSkill,
+  type HabitPlan,
+  type SkillBuildingPhase,
+  type TrackingCoachedPhase,
+  SKILL_ICONS,
+  deriveHabitMode,
+} from "@/types/habits";
+import { s } from "../HabitCreationWizard.styles";
+
+interface Step3ConfirmProps {
+  habitName: string;
+  habitIcon: string;
+  habitTargetSkill: TargetSkill;
+  wantPlan: boolean;
+  previewedPlan: HabitPlan | null;
+  isLoading: boolean;
+}
+
+export function PlanReviewPanel({
+  habitName,
+  habitIcon,
+  habitTargetSkill,
+  wantPlan,
+  previewedPlan,
+  isLoading,
+}: Step3ConfirmProps) {
+  const t = useTranslations("habitWizard.step3");
+  const tSkills = useTranslations("habits.skills");
+  const mode = deriveHabitMode(habitTargetSkill);
+  const needsPlan = mode === "skill-building" || wantPlan;
+
+  if (isLoading) {
+    return (
+      <Box {...s.loadingContainer}>
+        <Spinner size="xl" borderWidth="4px" color="primary" />
+        <Heading size="lg" {...s.loadingTitle}>
+          {t("loadingTitle")}
+        </Heading>
+        <Text {...s.loadingSubtitle}>{t("loadingSubtitle")}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box {...s.formStack}>
+      <Box {...s.summaryCard}>
+        <Box {...s.summaryStack}>
+          <Text fontWeight="800" fontSize="lg">
+            {habitIcon} {habitName}
+          </Text>
+          <Text>
+            {SKILL_ICONS[habitTargetSkill]} {tSkills(`${habitTargetSkill}.name`)}
+            {" · "}
+            {mode === "skill-building" ? t("modeSkillBuilding") : t("modeTracking")}
+          </Text>
+        </Box>
+      </Box>
+
+      {previewedPlan && (
+        <Box {...s.planPreview}>
+          <Text {...s.planPreviewTitle}>📋 {t("planPreviewTitle")}</Text>
+          <Box {...s.planStrategy}>
+            <Text>
+              <Text as="strong">{t("strategyLabel")}:</Text> {previewedPlan.strategy}
+            </Text>
+            <Text>
+              <Text as="strong">{t("metricsLabel")}:</Text> {previewedPlan.success_metrics}
+            </Text>
+            <Text>
+              <Text as="strong">{t("timeLabel")}:</Text> {previewedPlan.total_time_per_day_minutes}{" "}
+              min/dia
+            </Text>
+          </Box>
+          {previewedPlan.phases.map((phase) => (
+            <Box key={phase.phase} {...s.phaseCard}>
+              <Text {...s.phaseHeader}>
+                Fase {phase.phase} · {phase.days} dias
+              </Text>
+              <Text {...s.phaseTitle}>{phase.theme}</Text>
+              {"daily_tasks" in phase ? (
+                <Box {...s.taskList}>
+                  {(phase as SkillBuildingPhase).daily_tasks.map((task, i) => (
+                    <Text key={i} {...s.taskItem}>
+                      → {task}
+                    </Text>
+                  ))}
+                </Box>
+              ) : (
+                <Box>
+                  <Text {...s.taskItem}>{(phase as TrackingCoachedPhase).weekly_focus}</Text>
+                  <Text {...s.taskItem}>💡 {(phase as TrackingCoachedPhase).tip}</Text>
+                </Box>
+              )}
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {!previewedPlan && needsPlan && (
+        <Box border="3px solid black" bg="surface.yellow" p={3}>
+          <Text fontSize="sm" fontWeight="bold">
+            {t("planPending")}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/habits/wizard/SkillCard.tsx
+++ b/components/habits/wizard/SkillCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Box, HStack, Text } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { Tooltip } from "@/components/ui/tooltip";
+import type { TargetSkill } from "@/types/habits";
+import { SKILL_METADATA } from "@/types/habits";
+
+interface SkillCardProps {
+  skill: TargetSkill;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+export function SkillCard({ skill, isSelected, onClick }: SkillCardProps) {
+  const t = useTranslations();
+  const metadata = SKILL_METADATA[skill];
+
+  const skillName = t(metadata.label);
+  const shortDesc = t(metadata.shortDescription);
+  const longDesc = metadata.longDescription ? t(metadata.longDescription) : null;
+
+  const isBehavioral = metadata.category === "behavioral";
+
+  const tooltipContent =
+    isBehavioral && longDesc ? (
+      <Box maxW="260px" p={1}>
+        <Text fontWeight="bold" fontSize="xs" textTransform="uppercase" mb={1}>
+          {shortDesc}
+        </Text>
+        <Text fontSize="xs" lineHeight="1.5">
+          {longDesc}
+        </Text>
+      </Box>
+    ) : null;
+
+  return (
+    <Box
+      as="button"
+      w="full"
+      h="auto"
+      p={3}
+      border="2px solid black"
+      bg={isSelected ? "yellow.300" : "white"}
+      cursor="pointer"
+      transition="all 0.15s"
+      onClick={onClick}
+      _hover={{ boxShadow: "4px 4px 0 black" }}
+      _active={{ transform: "translate(2px, 2px)", boxShadow: "none" }}
+    >
+      <HStack justify="space-between" align="center" gap={2} w="full">
+        <HStack gap={3} flex="1">
+          <Text fontSize="2xl" lineHeight="1">
+            {metadata.icon}
+          </Text>
+          <Text fontWeight="bold" fontSize="sm" textTransform="uppercase" textAlign="left">
+            {skillName}
+          </Text>
+        </HStack>
+        {tooltipContent && (
+          <Tooltip
+            content={tooltipContent}
+            positioning={{ placement: "top" }}
+            showArrow={false}
+            contentProps={{
+              bg: "white",
+              border: "2px solid black",
+              borderRadius: "0",
+              boxShadow: "4px 4px 0 black",
+              color: "black",
+              p: 3,
+            }}
+          >
+            <Box
+              as="span"
+              display="inline-flex"
+              alignItems="center"
+              justifyContent="center"
+              w="18px"
+              h="18px"
+              border="2px solid black"
+              fontSize="10px"
+              fontWeight="black"
+              flexShrink={0}
+              cursor="help"
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
+              ?
+            </Box>
+          </Tooltip>
+        )}
+      </HStack>
+    </Box>
+  );
+}

--- a/components/habits/wizard/SkillPlanForm.tsx
+++ b/components/habits/wizard/SkillPlanForm.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Box, Input, Text, Textarea, Grid } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { s } from "../HabitCreationWizard.styles";
+import { step2SkillSchema, type Step2SkillData, LEVELS, WIZARD_FORM_ID } from "./types";
+
+interface Step2SkillProps {
+  defaultValues?: Partial<Step2SkillData>;
+  onNext: (_data: Step2SkillData) => void;
+}
+
+export function SkillPlanForm({ defaultValues, onNext }: Step2SkillProps) {
+  const t = useTranslations("habitWizard.step2Skill");
+
+  const { control, handleSubmit } = useForm<Step2SkillData>({
+    resolver: zodResolver(step2SkillSchema),
+    defaultValues: { struggles: "", availableMinutes: 30, level: "beginner", ...defaultValues },
+  });
+
+  return (
+    <Box as="form" id={WIZARD_FORM_ID} onSubmit={handleSubmit(onNext)}>
+      <Box {...s.formStack}>
+        <Box {...s.planNoteSkill}>
+          <Text {...s.planNoteText}>{t("planNote")}</Text>
+        </Box>
+
+        <Box>
+          <Text as="label" {...s.label}>
+            {t("strugglesLabel")}
+          </Text>
+          <Controller
+            name="struggles"
+            control={control}
+            render={({ field }) => (
+              <Textarea {...field} rows={4} placeholder={t("strugglesPh")} {...s.textarea} />
+            )}
+          />
+        </Box>
+
+        <Box>
+          <Text as="label" {...s.label}>
+            {t("timeLabel")}
+          </Text>
+          <Controller
+            name="availableMinutes"
+            control={control}
+            render={({ field }) => (
+              <Input
+                type="number"
+                min={5}
+                max={120}
+                fontWeight="bold"
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.valueAsNumber || 0)}
+                onBlur={field.onBlur}
+                name={field.name}
+                ref={field.ref}
+                {...s.input}
+              />
+            )}
+          />
+        </Box>
+
+        <Box>
+          <Text as="label" {...s.label}>
+            {t("levelLabel")}
+          </Text>
+          <Controller
+            name="level"
+            control={control}
+            render={({ field }) => (
+              <Grid templateColumns="repeat(3, 1fr)" gap={2}>
+                {LEVELS.map((l) => (
+                  <Button
+                    key={l}
+                    type="button"
+                    variant={field.value === l ? "primary" : "muted"}
+                    onClick={() => field.onChange(l)}
+                  >
+                    {t(`levels.${l}`)}
+                  </Button>
+                ))}
+              </Grid>
+            )}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/components/habits/wizard/TrackingOptionsForm.tsx
+++ b/components/habits/wizard/TrackingOptionsForm.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Box, Grid, Input, Text, Textarea } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { s } from "../HabitCreationWizard.styles";
+import { step2TrackingSchema, type Step2TrackingData, LEVELS, WIZARD_FORM_ID } from "./types";
+
+interface Step2TrackingProps {
+  defaultValues?: Partial<Step2TrackingData>;
+  onNext: (_data: Step2TrackingData) => void;
+}
+
+export function TrackingOptionsForm({ defaultValues, onNext }: Step2TrackingProps) {
+  const t = useTranslations("habitWizard.step2Tracking");
+
+  const { control, handleSubmit, watch } = useForm<Step2TrackingData>({
+    resolver: zodResolver(step2TrackingSchema),
+    defaultValues: {
+      wantPlan: false,
+      barrier: "",
+      availableMinutes: 30,
+      level: "beginner",
+      ...defaultValues,
+    },
+  });
+
+  const wantPlan = watch("wantPlan");
+
+  return (
+    <Box as="form" id={WIZARD_FORM_ID} onSubmit={handleSubmit(onNext)}>
+      <Box {...s.formStack}>
+        <Box {...s.planNoteTracking}>
+          <Text {...s.planNoteText}>{t("optionalNote")}</Text>
+        </Box>
+
+        <Controller
+          name="wantPlan"
+          control={control}
+          render={({ field }) => (
+            <Box {...s.toggleRow}>
+              <Text {...s.toggleLabel}>{t("wantPlanLabel")}</Text>
+              <Switch checked={field.value} onCheckedChange={(e) => field.onChange(e.checked)} />
+            </Box>
+          )}
+        />
+
+        {wantPlan && (
+          <>
+            <Box>
+              <Text as="label" {...s.label}>
+                {t("barrierLabel")}
+              </Text>
+              <Controller
+                name="barrier"
+                control={control}
+                render={({ field }) => (
+                  <Textarea {...field} rows={3} placeholder={t("barrierPh")} {...s.textarea} />
+                )}
+              />
+            </Box>
+
+            <Box>
+              <Text as="label" {...s.label}>
+                {t("timeLabel")}
+              </Text>
+              <Controller
+                name="availableMinutes"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    type="number"
+                    min={5}
+                    max={120}
+                    fontWeight="bold"
+                    value={field.value}
+                    onChange={(e) => field.onChange(e.target.valueAsNumber || 0)}
+                    onBlur={field.onBlur}
+                    name={field.name}
+                    ref={field.ref}
+                    {...s.input}
+                  />
+                )}
+              />
+            </Box>
+
+            <Box>
+              <Text as="label" {...s.label}>
+                {t("levelLabel")}
+              </Text>
+              <Controller
+                name="level"
+                control={control}
+                render={({ field }) => (
+                  <Grid templateColumns="repeat(3, 1fr)" gap={2}>
+                    {LEVELS.map((l) => (
+                      <Button
+                        key={l}
+                        type="button"
+                        variant={field.value === l ? "primary" : "muted"}
+                        onClick={() => field.onChange(l)}
+                      >
+                        {t(`levels.${l}`)}
+                      </Button>
+                    ))}
+                  </Grid>
+                )}
+              />
+            </Box>
+          </>
+        )}
+
+        {!wantPlan && (
+          <Box {...s.manualNote}>
+            <Text {...s.manualNoteText}>{t("manualNote")}</Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/habits/wizard/types.ts
+++ b/components/habits/wizard/types.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export type Level = "beginner" | "intermediate" | "advanced";
+
+export const LEVELS: Level[] = ["beginner", "intermediate", "advanced"];
+
+export const step1Schema = z.object({
+  name: z.string().min(1),
+  targetSkill: z.string().min(1),
+});
+
+export const step2SkillSchema = z.object({
+  struggles: z.string().min(1),
+  availableMinutes: z.number().int().min(5).max(120),
+  level: z.enum(["beginner", "intermediate", "advanced"]),
+});
+
+export const step2TrackingSchema = z.object({
+  wantPlan: z.boolean(),
+  barrier: z.string(),
+  availableMinutes: z.number().int().min(5).max(120),
+  level: z.enum(["beginner", "intermediate", "advanced"]),
+});
+
+export type Step1Data = z.infer<typeof step1Schema>;
+export type Step2SkillData = z.infer<typeof step2SkillSchema>;
+export type Step2TrackingData = z.infer<typeof step2TrackingSchema>;
+
+export const WIZARD_FORM_ID = "habit-wizard-form";


### PR DESCRIPTION
## Summary

- `HabitSetupForm` — Step 1: nome + seleção de target skill via `SkillCard`
- `SkillPlanForm` — Step 2a: formulário skill-building (struggles, tempo, nível)
- `TrackingOptionsForm` — Step 2b: formulário tracking-coached (barreira, métricas)
- `PlanReviewPanel` — Step 3: preview do plano gerado antes da confirmação
- `HabitCreationWizard` — orquestra os 3 steps com navegação e estado
- Schemas Zod para validação de cada step, styles compartilhados

## Dependências

- PR #41 — endpoints de habits ✅
- PR #42 — types, service e hooks ✅
- PR #43 — dialog, modal, switch, tooltip ✅

## Test plan

- [ ] Compilação sem erros (`yarn tsc --noEmit`)
- [ ] Navegação entre steps funciona (próximo / voltar)
- [ ] Validação Zod bloqueia avanço com campos inválidos
- [ ] Step 3 exibe o plano retornado pelo `usePreviewHabitPlan`