### PR TITLE
feat: add habits and habit wizard translations (en, es, pt)

### DIFF
--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -30,17 +30,14 @@
       "subtitle": "Research shows it takes 66 days to form an automatic habit. We break this into 3 phases — each with AI-powered guidance.",
       "phaseLabel": "Phase {num} · Days {days}",
       "phase1": {
-        "days": "1-14",
         "title": "Foundation",
         "desc": "Establish your routine. Create the trigger that makes it stick."
       },
       "phase2": {
-        "days": "15-44",
         "title": "Active Production",
         "desc": "Intentional growth. Every session harder than the last."
       },
       "phase3": {
-        "days": "45-66",
         "title": "Consolidation",
         "desc": "The habit runs itself. You become someone who just does this."
       }
@@ -193,6 +190,69 @@
     "openMenu": "Open menu",
     "closeMenu": "Close menu"
   },
+  "habits": {
+    "pageTitle": "Habits",
+    "newHabit": "+ New Habit",
+    "tooltipLimit": "You've reached the limit of {max} active habits. Complete a 66-day cycle or deactivate a habit to create another.",
+    "warningBanner": "⚠️ You have {count} active habits. Research shows focusing on fewer habits increases success. Consider completing a 66-day cycle before adding more.",
+    "warningBannerLimit": "⚠️ You have {count} active habits. Research shows focusing on fewer habits increases success. Complete a 66-day cycle or deactivate a habit to create another.",
+    "dismiss": "×",
+    "status": {
+      "ready": "Plan Ready",
+      "generating": "Generating...",
+      "pending": "Pending",
+      "failed": "Failed",
+      "skipped": "No Plan"
+    },
+    "mode": {
+      "skillBuilding": "📝 Skill-Building",
+      "tracking": "🎯 Tracking"
+    },
+    "streakDay": "DAY {current}/66",
+    "viewPlan": "▼ View 66-Day Plan",
+    "hidePlan": "▲ Hide Plan",
+    "strategy": "Strategy: {strategy}",
+    "minPerDay": "{minutes} min/day · {metrics}",
+    "phase": "Phase {phase} · Days {days}",
+    "generatingPlan": "⏳ Generating your 66-day plan...",
+    "planFailed": "❌ Plan generation failed",
+    "retry": "Retry",
+    "emptyTitle": "No habits yet",
+    "emptySubtitle": "Create your first habit to start your 66-day journey.",
+    "createFirst": "+ Create First Habit",
+    "skills": {
+      "en-US": {
+        "name": "English",
+        "short": "Develop oral fluency and listening comprehension",
+        "long": "Get a 66-day plan with structured daily tasks. The AI analyzes your writing and provides feedback on grammar, vocabulary, and pronunciation."
+      },
+      "es-ES": {
+        "name": "Spanish",
+        "short": "Master vocabulary and grammar structure",
+        "long": "Structured 3-phase plan with daily exercises. Real-time AI feedback on your linguistic progress."
+      },
+      "pt-BR": {
+        "name": "Portuguese",
+        "short": "Practice Portuguese writing and conversation",
+        "long": "For those learning Portuguese. 66 days with progressive tasks and contextualized feedback."
+      },
+      "general": {
+        "name": "General",
+        "short": "Reading, studying, productivity and varied habits",
+        "long": "Use for any habit that isn't physical or emotional wellness: reading, playing an instrument, personal organization. The AI tracks your consistency, triggers, and patterns — and suggests a micro-action for tomorrow."
+      },
+      "fitness": {
+        "name": "Fitness",
+        "short": "Gym, running, weightlifting and physical exercise",
+        "long": "Use for any physical practice. The AI tracks your energy, recovery, and training consistency — and suggests adjustments for your next session."
+      },
+      "mindfulness": {
+        "name": "Mindfulness",
+        "short": "Meditation, breathing and emotional well-being",
+        "long": "Use for mindfulness practices: meditation, breathing exercises, gratitude journaling, or body scan. The AI focuses on your emotional state, stress level, and quality of presence."
+      }
+    }
+  },
   "settings": {
     "badge": "Coming soon",
     "title": "Settings",
@@ -221,6 +281,10 @@
     "aiUsageLabel": "{used} of {limit} requests used",
     "aiUsageReset": "Resets daily at midnight UTC",
     "save": "Save Changes",
+    "toastSuccessTitle": "Profile updated",
+    "toastSuccessDesc": "Your changes have been saved successfully.",
+    "toastErrorTitle": "Save failed",
+    "toastErrorDesc": "Could not save changes. Please try again.",
     "timezone": {
       "america_sao_paulo": "America/São Paulo (UTC-3)",
       "america_new_york": "America/New York (UTC-5/-4)",
@@ -232,6 +296,112 @@
       "europe_paris": "Europe/Paris (UTC+1/+2)",
       "europe_madrid": "Europe/Madrid (UTC+1/+2)",
       "asia_tokyo": "Asia/Tokyo (UTC+9)"
+    }
+  },
+  "habitWizard": {
+    "title": "✨ New Habit",
+    "step1": {
+      "habitNameLabel": "Habit Name",
+      "habitNamePlaceholder": "e.g., Practice English 30m daily",
+      "targetSkillLabel": "Target Skill",
+      "langSkillsLabel": "🌍 Languages",
+      "langSkillsHint": "Get a 66-day plan with daily tasks. AI will analyze your writing and provide linguistic feedback.",
+      "behaviorLabel": "🎯 Behavioral",
+      "behaviorHint": "Track consistency with an optional plan. AI monitors patterns and offers weekly tips.",
+      "modeHintSkill": "📝 You'll receive a complete 66-day plan with structured daily tasks. AI will analyze your writing and provide linguistic feedback.",
+      "modeHintTracking": "🎯 The AI will track your mood, energy, and behavioral patterns.",
+      "next": "Next →"
+    },
+    "step2Skill": {
+      "planNote": "📝 AI will generate a full 66-day plan (Mandatory)",
+      "strugglesLabel": "Describe your struggles and goals",
+      "strugglesPh": "e.g., I freeze when speaking English. My vocabulary is limited for professional topics.",
+      "timeLabel": "Time per day (minutes)",
+      "levelLabel": "Experience Level",
+      "levels": {
+        "beginner": "Beginner",
+        "intermediate": "Intermediate",
+        "advanced": "Advanced"
+      },
+      "back": "← Back",
+      "generate": "Generate My 66-Day Plan →"
+    },
+    "step2Tracking": {
+      "optionalNote": "🎯 AI plan is optional for behavioral habits.",
+      "wantPlanLabel": "Generate AI consistency strategy?",
+      "barrierLabel": "What's your biggest barrier?",
+      "barrierPh": "e.g., I skip the gym on tired days.",
+      "strugglesLabel": "Describe your struggles and goals",
+      "strugglesPh": "e.g., I have trouble staying consistent.",
+      "timeLabel": "Time per day (minutes)",
+      "levelLabel": "Experience Level",
+      "levels": {
+        "beginner": "Beginner",
+        "intermediate": "Intermediate",
+        "advanced": "Advanced"
+      },
+      "manualNote": "Got it! You'll track this habit manually.",
+      "back": "← Back",
+      "nextWithPlan": "Generate Strategy →",
+      "next": "Next →"
+    },
+    "step3": {
+      "loadingTitle": "Generating your plan...",
+      "loadingSubtitle": "This usually takes a few seconds.",
+      "summaryTitle": "Habit Summary",
+      "planPreviewTitle": "AI-Generated Plan",
+      "strategyLabel": "Strategy",
+      "metricsLabel": "Success Metrics",
+      "timeLabel": "Time per day",
+      "nameLabel": "Name",
+      "skillLabel": "Skill",
+      "modeLabel": "Mode",
+      "planLabel": "Plan",
+      "modeSkillBuilding": "📝 Skill-Building",
+      "modeTracking": "🎯 Tracking-Coached",
+      "planReady": "✅ Generated",
+      "planPending": "⏳ Generating...",
+      "planSkipped": "⏭️ Skipped",
+      "regenerate": "🔄 Regenerate Plan",
+      "regenerateError": "Failed to regenerate plan. Please try again.",
+      "create": "✓ Confirm & Create",
+      "back": "← Back",
+      "errorTitle": "❌ Failed to generate plan",
+      "errorSubtitle": "Check your connection and try again.",
+      "rateLimitTitle": "⏳ AI is busy",
+      "rateLimitSubtitle": "Too many requests at once. Wait a few seconds and try again."
+    },
+    "skills": {
+      "en-US": {
+        "name": "English",
+        "short": "Develop oral fluency and listening comprehension",
+        "long": "Get a 66-day plan with structured daily tasks. The AI analyzes your writing and provides feedback on grammar, vocabulary, and pronunciation."
+      },
+      "es-ES": {
+        "name": "Spanish",
+        "short": "Master vocabulary and grammar structure",
+        "long": "Structured 3-phase plan with daily exercises. Real-time AI feedback on your linguistic progress."
+      },
+      "pt-BR": {
+        "name": "Portuguese",
+        "short": "Practice Portuguese writing and conversation",
+        "long": "For those learning Portuguese. 66 days with progressive tasks and contextualized feedback."
+      },
+      "general": {
+        "name": "General",
+        "short": "Reading, studying, productivity and varied habits",
+        "long": "Use for any habit that isn't physical or emotional wellness: reading, playing an instrument, personal organization. The AI tracks your consistency, triggers, and patterns — and suggests a micro-action for tomorrow."
+      },
+      "fitness": {
+        "name": "Fitness",
+        "short": "Gym, running, weightlifting and physical exercise",
+        "long": "Use for any physical practice. The AI tracks your energy, recovery, and training consistency — and suggests adjustments for your next session."
+      },
+      "mindfulness": {
+        "name": "Mindfulness",
+        "short": "Meditation, breathing and emotional well-being",
+        "long": "Use for mindfulness practices: meditation, breathing exercises, gratitude journaling, or body scan. The AI focuses on your emotional state, stress level, and quality of presence."
+      }
     }
   }
 }

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -30,17 +30,14 @@
       "subtitle": "La investigación muestra que toma 66 días formar un hábito automático. Dividimos esto en 3 fases — cada una con guía de IA.",
       "phaseLabel": "Fase {num} · Días {days}",
       "phase1": {
-        "days": "1-14",
         "title": "Fundación",
         "desc": "Establece la rutina. Crea el disparador que hace que el hábito funcione."
       },
       "phase2": {
-        "days": "15-44",
         "title": "Producción Activa",
         "desc": "Crecimiento intencional. Cada sesión más difícil que la anterior."
       },
       "phase3": {
-        "days": "45-66",
         "title": "Consolidación",
         "desc": "El hábito funciona solo. Te conviertes en quien simplemente lo hace."
       }
@@ -193,6 +190,69 @@
     "openMenu": "Abrir menú",
     "closeMenu": "Cerrar menú"
   },
+  "habits": {
+    "pageTitle": "Hábitos",
+    "newHabit": "+ Nuevo Hábito",
+    "tooltipLimit": "Has alcanzado el límite de {max} hábitos activos. Completa un ciclo de 66 días o desactiva un hábito para crear otro.",
+    "warningBanner": "⚠️ Tienes {count} hábitos activos. Las investigaciones muestran que enfocarse en menos hábitos aumenta el éxito. Considera completar un ciclo de 66 días antes de agregar más.",
+    "warningBannerLimit": "⚠️ Tienes {count} hábitos activos. Las investigaciones muestran que enfocarse en menos hábitos aumenta el éxito. Completa un ciclo de 66 días o desactiva un hábito para crear otro.",
+    "dismiss": "×",
+    "status": {
+      "ready": "Plan Listo",
+      "generating": "Generando...",
+      "pending": "Pendiente",
+      "failed": "Fallido",
+      "skipped": "Sin Plan"
+    },
+    "mode": {
+      "skillBuilding": "📝 Desarrollo",
+      "tracking": "🎯 Seguimiento"
+    },
+    "streakDay": "DÍA {current}/66",
+    "viewPlan": "▼ Ver Plan de 66 Días",
+    "hidePlan": "▲ Ocultar Plan",
+    "strategy": "Estrategia: {strategy}",
+    "minPerDay": "{minutes} min/día · {metrics}",
+    "phase": "Fase {phase} · Días {days}",
+    "generatingPlan": "⏳ Generando tu plan de 66 días...",
+    "planFailed": "❌ Error al generar el plan",
+    "retry": "Reintentar",
+    "emptyTitle": "Aún no hay hábitos",
+    "emptySubtitle": "Crea tu primer hábito para comenzar tu viaje de 66 días.",
+    "createFirst": "+ Crear Primer Hábito",
+    "skills": {
+      "en-US": {
+        "name": "Inglés",
+        "short": "Desarrolla fluidez oral y comprensión auditiva",
+        "long": "Obtén un plan de 66 días con tareas diarias estructuradas. La IA analiza tu escritura y proporciona retroalimentación sobre gramática, vocabulario y pronunciación."
+      },
+      "es-ES": {
+        "name": "Español",
+        "short": "Domina el vocabulario y la estructura gramatical",
+        "long": "Plan estructurado de 3 fases con ejercicios diarios. Retroalimentación de IA en tiempo real sobre tu progreso lingüístico."
+      },
+      "pt-BR": {
+        "name": "Portugués",
+        "short": "Practica escritura y conversación en portugués",
+        "long": "Para quienes aprenden portugués. 66 días con tareas progresivas y retroalimentación contextualizada."
+      },
+      "general": {
+        "name": "General",
+        "short": "Lectura, estudio, productividad y hábitos variados",
+        "long": "Úsalo para cualquier hábito que no sea físico ni de bienestar emocional: lectura, tocar un instrumento, organización personal. La IA rastrea tu consistencia, gatillos y patrones — y sugiere una micro-acción para mañana."
+      },
+      "fitness": {
+        "name": "Fitness",
+        "short": "Gimnasio, running, musculación y ejercicio físico",
+        "long": "Úsalo para cualquier práctica física. La IA rastrea tu energía, recuperación y consistencia de entrenamiento — y sugiere ajustes para tu próxima sesión."
+      },
+      "mindfulness": {
+        "name": "Mindfulness",
+        "short": "Meditación, respiración y bienestar emocional",
+        "long": "Úsalo para prácticas de atención plena: meditación, ejercicios de respiración, diario de gratitud o escaneo corporal. La IA se enfoca en tu estado emocional, nivel de estrés y calidad de presencia."
+      }
+    }
+  },
   "settings": {
     "badge": "Próximamente",
     "title": "Configuración",
@@ -221,6 +281,10 @@
     "aiUsageLabel": "{used} de {limit} solicitudes usadas",
     "aiUsageReset": "Se reinicia diariamente a medianoche UTC",
     "save": "Guardar Cambios",
+    "toastSuccessTitle": "Perfil actualizado",
+    "toastSuccessDesc": "Tus cambios se guardaron correctamente.",
+    "toastErrorTitle": "Error al guardar",
+    "toastErrorDesc": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
     "timezone": {
       "america_sao_paulo": "América/São Paulo (UTC-3)",
       "america_new_york": "América/Nueva York (UTC-5/-4)",
@@ -232,6 +296,112 @@
       "europe_paris": "Europa/París (UTC+1/+2)",
       "europe_madrid": "Europa/Madrid (UTC+1/+2)",
       "asia_tokyo": "Asia/Tokio (UTC+9)"
+    }
+  },
+  "habitWizard": {
+    "title": "✨ Nuevo Hábito",
+    "step1": {
+      "habitNameLabel": "Nombre del Hábito",
+      "habitNamePlaceholder": "ej: Practicar inglés 30min/día",
+      "targetSkillLabel": "Habilidad Objetivo",
+      "langSkillsLabel": "🌍 Idiomas",
+      "langSkillsHint": "Obtén un plan de 66 días con tareas diarias. La IA analizará tu escritura y proporcionará retroalimentación lingüística.",
+      "behaviorLabel": "🎯 Comportamental",
+      "behaviorHint": "Monitorea consistencia con un plan opcional. La IA rastrea patrones y ofrece consejos semanales.",
+      "modeHintSkill": "📝 Recibirás un plan completo de 66 días con tareas diarias estructuradas. La IA analizará tu escritura y proporcionará retroalimentación lingüística.",
+      "modeHintTracking": "🎯 La IA rastreará tu estado de ánimo, energía y patrones conductuales.",
+      "next": "Siguiente →"
+    },
+    "step2Skill": {
+      "planNote": "📝 La IA generará un plan completo de 66 días (Obligatorio)",
+      "strugglesLabel": "Describe tus dificultades y objetivos",
+      "strugglesPh": "ej: Me bloqueo al hablar inglés. Mi vocabulario es limitado para temas profesionales.",
+      "timeLabel": "Tiempo por día (minutos)",
+      "levelLabel": "Nivel de Experiencia",
+      "levels": {
+        "beginner": "Principiante",
+        "intermediate": "Intermedio",
+        "advanced": "Avanzado"
+      },
+      "back": "← Volver",
+      "generate": "Generar Mi Plan de 66 Días →"
+    },
+    "step2Tracking": {
+      "optionalNote": "🎯 El plan de IA es opcional para hábitos conductuales.",
+      "wantPlanLabel": "¿Generar estrategia de consistencia con IA?",
+      "barrierLabel": "¿Cuál es tu mayor barrera?",
+      "barrierPh": "ej: Me salto el gym en los días de cansancio.",
+      "strugglesLabel": "Describe tus dificultades y objetivos",
+      "strugglesPh": "ej: Tengo dificultades para mantener la consistencia.",
+      "timeLabel": "Tiempo por día (minutos)",
+      "levelLabel": "Nivel de Experiencia",
+      "levels": {
+        "beginner": "Principiante",
+        "intermediate": "Intermedio",
+        "advanced": "Avanzado"
+      },
+      "manualNote": "¡Entendido! Seguirás este hábito manualmente.",
+      "back": "← Volver",
+      "nextWithPlan": "Generar Estrategia →",
+      "next": "Siguiente →"
+    },
+    "step3": {
+      "loadingTitle": "Generando tu plan...",
+      "loadingSubtitle": "Esto suele tardar unos segundos.",
+      "summaryTitle": "Resumen del Hábito",
+      "planPreviewTitle": "Plan Generado por IA",
+      "strategyLabel": "Estrategia",
+      "metricsLabel": "Métricas de Éxito",
+      "timeLabel": "Tiempo por día",
+      "nameLabel": "Nombre",
+      "skillLabel": "Habilidad",
+      "modeLabel": "Modo",
+      "planLabel": "Plan",
+      "modeSkillBuilding": "📝 Desarrollo de Habilidad",
+      "modeTracking": "🎯 Seguimiento con Coaching",
+      "planReady": "✅ Generado",
+      "planPending": "⏳ Generando...",
+      "planSkipped": "⏭️ Omitido",
+      "regenerate": "🔄 Regenerar Plan",
+      "regenerateError": "Error al regenerar el plan. Inténtalo de nuevo.",
+      "create": "✓ Confirmar y Crear",
+      "back": "← Volver",
+      "errorTitle": "❌ Error al generar el plan",
+      "errorSubtitle": "Verifica tu conexión e inténtalo de nuevo.",
+      "rateLimitTitle": "⏳ IA ocupada",
+      "rateLimitSubtitle": "Demasiadas solicitudes a la vez. Espera unos segundos e inténtalo de nuevo."
+    },
+    "skills": {
+      "en-US": {
+        "name": "Inglés",
+        "short": "Desarrolla fluidez oral y comprensión auditiva",
+        "long": "Obtén un plan de 66 días con tareas diarias estructuradas. La IA analiza tu escritura y proporciona retroalimentación sobre gramática, vocabulario y pronunciación."
+      },
+      "es-ES": {
+        "name": "Español",
+        "short": "Domina el vocabulario y la estructura gramatical",
+        "long": "Plan estructurado de 3 fases con ejercicios diarios. Retroalimentación de IA en tiempo real sobre tu progreso lingüístico."
+      },
+      "pt-BR": {
+        "name": "Portugués",
+        "short": "Practica escritura y conversación en portugués",
+        "long": "Para quienes aprenden portugués. 66 días con tareas progresivas y retroalimentación contextualizada."
+      },
+      "general": {
+        "name": "General",
+        "short": "Lectura, estudio, productividad y hábitos variados",
+        "long": "Úsalo para cualquier hábito que no sea físico ni de bienestar emocional: lectura, tocar un instrumento, organización personal. La IA rastrea tu consistencia, gatillos y patrones — y sugiere una micro-acción para mañana."
+      },
+      "fitness": {
+        "name": "Fitness",
+        "short": "Gimnasio, running, musculación y ejercicio físico",
+        "long": "Úsalo para cualquier práctica física. La IA rastrea tu energía, recuperación y consistencia de entrenamiento — y sugiere ajustes para tu próxima sesión."
+      },
+      "mindfulness": {
+        "name": "Mindfulness",
+        "short": "Meditación, respiración y bienestar emocional",
+        "long": "Úsalo para prácticas de atención plena: meditación, ejercicios de respiración, diario de gratitud o escaneo corporal. La IA se enfoca en tu estado emocional, nivel de estrés y calidad de presencia."
+      }
     }
   }
 }

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -30,17 +30,14 @@
       "subtitle": "A pesquisa mostra que leva 66 dias para formar um hábito automático. Dividimos isso em 3 fases — cada uma com orientação de IA.",
       "phaseLabel": "Fase {num} · Dias {days}",
       "phase1": {
-        "days": "1-14",
         "title": "Fundação",
         "desc": "Estabeleça a rotina. Crie o gatilho que faz o hábito acontecer."
       },
       "phase2": {
-        "days": "15-44",
         "title": "Produção Ativa",
         "desc": "Crescimento intencional. Cada sessão mais difícil que a anterior."
       },
       "phase3": {
-        "days": "45-66",
         "title": "Consolidação",
         "desc": "O hábito vira piloto automático. Você vira quem simplesmente faz isso."
       }
@@ -193,6 +190,69 @@
     "openMenu": "Abrir menu",
     "closeMenu": "Fechar menu"
   },
+  "habits": {
+    "pageTitle": "Hábitos",
+    "newHabit": "+ Novo Hábito",
+    "tooltipLimit": "Você atingiu o limite de {max} hábitos ativos. Complete um ciclo de 66 dias ou desative um hábito para criar outro.",
+    "warningBanner": "⚠️ Você tem {count} hábitos ativos. Pesquisas mostram que focar em menos hábitos aumenta o sucesso. Considere completar um ciclo de 66 dias antes de adicionar mais.",
+    "warningBannerLimit": "⚠️ Você tem {count} hábitos ativos. Pesquisas mostram que focar em menos hábitos aumenta o sucesso. Complete um ciclo de 66 dias ou desative um hábito para criar outro.",
+    "dismiss": "×",
+    "status": {
+      "ready": "Plano Pronto",
+      "generating": "Gerando...",
+      "pending": "Pendente",
+      "failed": "Falhou",
+      "skipped": "Sem Plano"
+    },
+    "mode": {
+      "skillBuilding": "📝 Desenvolvimento",
+      "tracking": "🎯 Rastreamento"
+    },
+    "streakDay": "DIA {current}/66",
+    "viewPlan": "▼ Ver Plano de 66 Dias",
+    "hidePlan": "▲ Ocultar Plano",
+    "strategy": "Estratégia: {strategy}",
+    "minPerDay": "{minutes} min/dia · {metrics}",
+    "phase": "Fase {phase} · Dias {days}",
+    "generatingPlan": "⏳ Gerando seu plano de 66 dias...",
+    "planFailed": "❌ Falha ao gerar o plano",
+    "retry": "Tentar novamente",
+    "emptyTitle": "Nenhum hábito ainda",
+    "emptySubtitle": "Crie seu primeiro hábito para começar sua jornada de 66 dias.",
+    "createFirst": "+ Criar Primeiro Hábito",
+    "skills": {
+      "en-US": {
+        "name": "Inglês",
+        "short": "Desenvolva fluência oral e compreensão auditiva",
+        "long": "Receba um plano de 66 dias com tarefas diárias estruturadas. A IA analisa sua escrita e dá feedback sobre gramática, vocabulário e pronúncia."
+      },
+      "es-ES": {
+        "name": "Espanhol",
+        "short": "Domine vocabulário e estrutura gramatical",
+        "long": "Plano estruturado de 3 fases com exercícios diários. Feedback de IA em tempo real sobre seus avanços linguísticos."
+      },
+      "pt-BR": {
+        "name": "Português",
+        "short": "Pratique escrita e conversação em português",
+        "long": "Para quem está aprendendo português. 66 dias com tarefas progressivas e feedback contextualizado."
+      },
+      "general": {
+        "name": "Geral",
+        "short": "Leitura, estudo, produtividade e hábitos variados",
+        "long": "Use para qualquer hábito que não é físico nem de bem-estar emocional: leitura, tocar instrumento, organização pessoal. A IA rastreia sua consistência, gatilhos e padrões — e sugere uma micro-ação para amanhã."
+      },
+      "fitness": {
+        "name": "Fitness",
+        "short": "Academia, corrida, musculação e exercícios físicos",
+        "long": "Use para qualquer prática física. A IA rastreia sua energia, recuperação e consistência de treino — e sugere ajustes para sua próxima sessão."
+      },
+      "mindfulness": {
+        "name": "Mindfulness",
+        "short": "Meditação, respiração consciente e bem-estar emocional",
+        "long": "Use para práticas de atenção plena: meditação, exercícios de respiração, diário de gratidão ou escaneamento corporal. A IA foca no seu estado emocional, nível de estresse e qualidade da presença."
+      }
+    }
+  },
   "settings": {
     "badge": "Em construção",
     "title": "Configurações",
@@ -221,6 +281,10 @@
     "aiUsageLabel": "{used} de {limit} requisições usadas",
     "aiUsageReset": "Reinicia diariamente à meia-noite UTC",
     "save": "Salvar Alterações",
+    "toastSuccessTitle": "Perfil atualizado",
+    "toastSuccessDesc": "Suas alterações foram salvas com sucesso.",
+    "toastErrorTitle": "Erro ao salvar",
+    "toastErrorDesc": "Não foi possível salvar as alterações. Tente novamente.",
     "timezone": {
       "america_sao_paulo": "América/São Paulo (UTC-3)",
       "america_new_york": "América/Nova York (UTC-5/-4)",
@@ -232,6 +296,112 @@
       "europe_paris": "Europa/Paris (UTC+1/+2)",
       "europe_madrid": "Europa/Madri (UTC+1/+2)",
       "asia_tokyo": "Ásia/Tóquio (UTC+9)"
+    }
+  },
+  "habitWizard": {
+    "title": "✨ Novo Hábito",
+    "step1": {
+      "habitNameLabel": "Nome do Hábito",
+      "habitNamePlaceholder": "ex: Praticar Inglês 30min/dia",
+      "targetSkillLabel": "Habilidade Alvo",
+      "langSkillsLabel": "🌍 Idiomas",
+      "langSkillsHint": "Receba um plano de 66 dias com tarefas diárias. A IA analisará sua escrita e dará feedback linguístico.",
+      "behaviorLabel": "🎯 Comportamental",
+      "behaviorHint": "Rastreie consistência com um plano opcional. A IA acompanha padrões e oferece dicas semanais.",
+      "modeHintSkill": "📝 Você receberá um plano completo de 66 dias com tarefas diárias estruturadas. A IA analisará sua escrita e dará feedback linguístico.",
+      "modeHintTracking": "🎯 A IA vai rastrear seu humor, energia e padrões comportamentais.",
+      "next": "Próximo →"
+    },
+    "step2Skill": {
+      "planNote": "📝 A IA vai gerar um plano completo de 66 dias (Obrigatório)",
+      "strugglesLabel": "Descreva suas dificuldades e objetivos",
+      "strugglesPh": "ex: Trava ao falar inglês. Vocabulário limitado para tópicos profissionais.",
+      "timeLabel": "Tempo por dia (minutos)",
+      "levelLabel": "Nível de Experiência",
+      "levels": {
+        "beginner": "Iniciante",
+        "intermediate": "Intermediário",
+        "advanced": "Avançado"
+      },
+      "back": "← Voltar",
+      "generate": "Gerar Meu Plano de 66 Dias →"
+    },
+    "step2Tracking": {
+      "optionalNote": "🎯 Plano de IA é opcional para hábitos comportamentais.",
+      "wantPlanLabel": "Gerar estratégia de consistência com IA?",
+      "barrierLabel": "Qual é sua maior barreira?",
+      "barrierPh": "ex: Pulo a academia nos dias cansativos.",
+      "strugglesLabel": "Descreva suas dificuldades e objetivos",
+      "strugglesPh": "ex: Tenho dificuldade em manter a consistência.",
+      "timeLabel": "Tempo por dia (minutos)",
+      "levelLabel": "Nível de Experiência",
+      "levels": {
+        "beginner": "Iniciante",
+        "intermediate": "Intermediário",
+        "advanced": "Avançado"
+      },
+      "manualNote": "Entendido! Você vai rastrear este hábito manualmente.",
+      "back": "← Voltar",
+      "nextWithPlan": "Gerar Estratégia →",
+      "next": "Próximo →"
+    },
+    "step3": {
+      "loadingTitle": "Gerando seu plano...",
+      "loadingSubtitle": "Isso geralmente leva alguns segundos.",
+      "summaryTitle": "Resumo do Hábito",
+      "planPreviewTitle": "Plano Gerado pela IA",
+      "strategyLabel": "Estratégia",
+      "metricsLabel": "Métricas de Sucesso",
+      "timeLabel": "Tempo por dia",
+      "nameLabel": "Nome",
+      "skillLabel": "Habilidade",
+      "modeLabel": "Modo",
+      "planLabel": "Plano",
+      "modeSkillBuilding": "📝 Desenvolvimento de Habilidade",
+      "modeTracking": "🎯 Rastreamento com Coaching",
+      "planReady": "✅ Gerado",
+      "planPending": "⏳ Gerando...",
+      "planSkipped": "⏭️ Ignorado",
+      "regenerate": "🔄 Regenerar Plano",
+      "regenerateError": "Falha ao regenerar o plano. Tente novamente.",
+      "create": "✓ Confirmar e Criar",
+      "back": "← Voltar",
+      "errorTitle": "❌ Falha ao gerar o plano",
+      "errorSubtitle": "Verifique sua conexão e tente novamente.",
+      "rateLimitTitle": "⏳ IA sobrecarregada",
+      "rateLimitSubtitle": "Muitas requisições ao mesmo tempo. Aguarde alguns segundos e tente novamente."
+    },
+    "skills": {
+      "en-US": {
+        "name": "Inglês",
+        "short": "Desenvolva fluência oral e compreensão auditiva",
+        "long": "Receba um plano de 66 dias com tarefas diárias estruturadas. A IA analisa sua escrita e dá feedback sobre gramática, vocabulário e pronúncia."
+      },
+      "es-ES": {
+        "name": "Espanhol",
+        "short": "Domine vocabulário e estrutura gramatical",
+        "long": "Plano estruturado de 3 fases com exercícios diários. Feedback de IA em tempo real sobre seus avanços linguísticos."
+      },
+      "pt-BR": {
+        "name": "Português",
+        "short": "Pratique escrita e conversação em português",
+        "long": "Para quem está aprendendo português. 66 dias com tarefas progressivas e feedback contextualizado."
+      },
+      "general": {
+        "name": "Geral",
+        "short": "Leitura, estudo, produtividade e hábitos variados",
+        "long": "Use para qualquer hábito que não é físico nem de bem-estar emocional: leitura, tocar instrumento, organização pessoal. A IA rastreia sua consistência, gatilhos e padrões — e sugere uma micro-ação para amanhã."
+      },
+      "fitness": {
+        "name": "Fitness",
+        "short": "Academia, corrida, musculação e exercícios físicos",
+        "long": "Use para qualquer prática física. A IA rastreia sua energia, recuperação e consistência de treino — e sugere ajustes para sua próxima sessão."
+      },
+      "mindfulness": {
+        "name": "Mindfulness",
+        "short": "Meditação, respiração consciente e bem-estar emocional",
+        "long": "Use para práticas de atenção plena: meditação, exercícios de respiração, diário de gratidão ou escaneamento corporal. A IA foca no seu estado emocional, nível de estresse e qualidade da presença."
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adiciona namespaces `habits` e `habitWizard` aos três arquivos de locale
- Cobre todo o copy da habits list page e do creation wizard
- 519 inserções entre `en-US.json`, `es-ES.json` e `pt-BR.json`

## Dependências

- PR #44 — habit creation wizard ✅

## Test plan

- [ ] Todos os keys existentes continuam funcionando (sem regressão)
- [ ] Keys de `habits` e `habitWizard` carregam corretamente nos três idiomas