### PR TITLE
feat: add habits list page with plan visualization

### DIFF
--- a/app/[locale]/(app)/habits/habits.styles.ts
+++ b/app/[locale]/(app)/habits/habits.styles.ts
@@ -28,20 +28,6 @@ export const s = {
     position: "relative" as const,
   },
 
-  tooltip: {
-    position: "absolute",
-    left: 0,
-    bottom: "100%",
-    mb: 2,
-    w: "280px",
-    p: 3,
-    bg: "surface.coral",
-    border: "2px solid black",
-    fontSize: "sm",
-    fontWeight: "bold",
-    zIndex: 50,
-  },
-
   banner: {
     p: 4,
     mb: 6,
@@ -218,6 +204,7 @@ export const s = {
     border: "2px solid black",
     bg: "surface.yellow",
     p: 4,
+    animation: "pulse 2s infinite",
   },
 
   failedStatus: {

--- a/app/[locale]/(app)/habits/page.tsx
+++ b/app/[locale]/(app)/habits/page.tsx
@@ -5,6 +5,7 @@ import { Box, Heading, Text, HStack } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
 import { HabitCreationWizard } from "@/components/habits/HabitCreationWizard";
 import { useHabits } from "@/lib/hooks/useHabits";
 import {
@@ -32,7 +33,6 @@ export default function HabitsPage(): React.JSX.Element {
   const { data: habits = [], isLoading } = useHabits();
   const [showWizard, setShowWizard] = useState(false);
   const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
-  const [showTooltip, setShowTooltip] = useState(false);
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
   const activeCount = habits.filter((h: Habit) => h.is_active).length;
@@ -43,16 +43,16 @@ export default function HabitsPage(): React.JSX.Element {
     queryClient.invalidateQueries({ queryKey: ["habits"] });
   };
 
+  const handleRetryPlan = (habitId: string) => {
+    // TODO: chamar endpoint REGENERATE_PLAN quando o hook estiver disponível
+    queryClient.invalidateQueries({ queryKey: ["habits", habitId] });
+  };
+
   return (
     <Box {...s.page}>
       <Box {...s.header}>
         <Heading {...s.pageTitle}>🎯 {t("pageTitle")}</Heading>
-        <Box
-          position="relative"
-          overflow="visible"
-          onMouseEnter={() => setShowTooltip(true)}
-          onMouseLeave={() => setShowTooltip(false)}
-        >
+        <Tooltip content={t("tooltipLimit", { max: MAX_ACTIVE_HABITS })} disabled={!isAtLimit}>
           <Button
             onClick={() => !isAtLimit && setShowWizard(true)}
             disabled={isAtLimit}
@@ -63,10 +63,7 @@ export default function HabitsPage(): React.JSX.Element {
           >
             {t("newHabit")}
           </Button>
-          {isAtLimit && showTooltip && (
-            <Box {...s.tooltip}>{t("tooltipLimit", { max: MAX_ACTIVE_HABITS })}</Box>
-          )}
-        </Box>
+        </Tooltip>
       </Box>
 
       {showWarning && (!bannerDismissed || isAtLimit) && (
@@ -81,9 +78,13 @@ export default function HabitsPage(): React.JSX.Element {
               : t("warningBanner", { count: activeCount })}
           </Text>
           {!isAtLimit && (
-            <Box {...s.bannerDismiss} as="button" onClick={() => setBannerDismissed(true)}>
+            <Button
+              {...s.bannerDismiss}
+              aria-label={t("dismiss")}
+              onClick={() => setBannerDismissed(true)}
+            >
               {t("dismiss")}
-            </Box>
+            </Button>
           )}
         </Box>
       )}
@@ -182,7 +183,7 @@ export default function HabitsPage(): React.JSX.Element {
               )}
 
               {habit.plan_status === "generating" && (
-                <Box {...s.generatingStatus} className="animate-pulse">
+                <Box {...s.generatingStatus}>
                   <Text fontSize="sm" fontWeight="bold">
                     {t("generatingPlan")}
                   </Text>
@@ -194,7 +195,7 @@ export default function HabitsPage(): React.JSX.Element {
                   <Text fontSize="sm" fontWeight="bold">
                     {t("planFailed")}
                   </Text>
-                  <Button variant="muted" fontSize="sm">
+                  <Button variant="muted" fontSize="sm" onClick={() => handleRetryPlan(habit.id)}>
                     {t("retry")}
                   </Button>
                 </Box>
@@ -209,7 +210,13 @@ export default function HabitsPage(): React.JSX.Element {
           <Text {...s.emptyIcon}>🎯</Text>
           <Heading {...s.emptyTitle}>{t("emptyTitle")}</Heading>
           <Text {...s.emptySubtitle}>{t("emptySubtitle")}</Text>
-          <Button onClick={() => setShowWizard(true)} variant="primary" px={8} py={6}>
+          <Button
+            onClick={() => !isAtLimit && setShowWizard(true)}
+            disabled={isAtLimit}
+            variant="primary"
+            px={8}
+            py={6}
+          >
             {t("createFirst")}
           </Button>
         </Box>


### PR DESCRIPTION
## Summary

- Página principal de habits com lista de hábitos (streak, plan status, phase info)
- Detalhes do plano expansíveis por hábito
- Warning banner para threshold de quantidade de hábitos
- Tooltip no limite máximo de hábitos
- Abre o `HabitCreationWizard` via modal

## Dependências

- PR #41 — endpoints ✅
- PR #42 — types, service e hooks ✅
- PR #43 — dialog, modal, switch, tooltip ✅
- PR #44 — habit creation wizard ✅
- PR #45 — translations ✅

## Test plan

- [ ] Compilação sem erros (`yarn tsc --noEmit`)
- [ ] Página carrega lista de habits via `useHabits`
- [ ] Wizard abre ao clicar em "criar hábito"
- [ ] Warning banner aparece ao atingir threshold
- [ ] Tooltip exibe mensagem ao atingir limite máximo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Novas Funcionalidades

* Adicionada nova página de gerenciamento de hábitos, permitindo criar, visualizar e gerenciar hábitos com planos detalhados, rastreamento de progresso e indicadores de limite. Interface inclui estados de carregamento, banner informativo adaptável e suporte para diferentes fases de desenvolvimento de habilidades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->