### PR TITLE
fix: add explicit px to input/textarea to prevent padding loss in production

### DIFF
--- a/components/habits/styles.ts
+++ b/components/habits/styles.ts
@@ -18,6 +18,7 @@ export const s = {
     bg: "white",
     border: "2px solid black",
     borderRadius: "0",
+    px: 3,
     _focus: { ring: "2px", ringColor: "ring" },
   },
 
@@ -25,6 +26,7 @@ export const s = {
     bg: "white",
     border: "2px solid black",
     borderRadius: "0",
+    px: 3,
     resize: "none",
     _focus: { ring: "2px", ringColor: "ring" },
   },


### PR DESCRIPTION
## Summary
- Adds `px: 3` explicitly to `s.input` and `s.textarea` in `components/habits/styles.ts`
- Prevents padding loss in Next.js production builds where Chakra UI recipe-based padding can be overridden by atomic CSS from other style props (`border`, `bg`)

## Root cause
In dev, Chakra styles are injected dynamically (last write wins). In production, CSS is extracted into static files — recipe styles may load before component-level style props, causing the recipe's `px` to lose in the cascade.

## Test plan
- [ ] Verify input has correct horizontal padding in production (Vercel preview deploy)
- [ ] Confirm local dev still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Estilos**
  * Aumentado o espaçamento interno em campos de entrada e áreas de texto para melhor usabilidade e legibilidade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->