### PR TITLE
refactor: update Modal with brutal close button and ReactNode title

### DIFF
--- a/components/ui/modal.styles.ts
+++ b/components/ui/modal.styles.ts
@@ -1,0 +1,49 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  content: {
+    bg: "card",
+    border: "3px solid black",
+    boxShadow: "brutal",
+    w: "100%",
+    maxH: "90vh",
+    overflowY: "auto" as const,
+    p: 6,
+  },
+
+  header: {
+    p: 0,
+    mb: 6,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+  },
+
+  title: {
+    fontSize: "2xl",
+    fontWeight: "800",
+    textTransform: "uppercase" as const,
+    flex: 1,
+    pr: 4,
+  },
+
+  closeBtn: {
+    w: 10,
+    h: 10,
+    border: "3px solid black",
+    bg: "accent",
+    color: "white",
+    fontWeight: "900",
+    fontSize: "lg",
+    cursor: "pointer",
+    boxShadow: "brutal-sm",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    transition: "transform 0.1s ease, box-shadow 0.1s ease",
+    _hover: { transform: "translate(-1px, -1px)", boxShadow: "brutal" },
+    _active: { transform: "translate(1px, 1px)", boxShadow: "none" },
+    _focusVisible: { outline: "3px solid", outlineColor: "ring", outlineOffset: "2px" },
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -8,6 +8,7 @@ import {
   DialogBody,
   DialogFooter,
 } from "./dialog";
+import { s } from "./modal.styles";
 
 export interface ModalProps {
   open: boolean;
@@ -21,46 +22,10 @@ export interface ModalProps {
 export function Modal({ open, onClose, title, footer, maxW = "520px", children }: ModalProps) {
   return (
     <DialogRoot open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <DialogContent
-        bg="card"
-        border="3px solid black"
-        boxShadow="brutal"
-        maxW={maxW}
-        w="100%"
-        maxH="90vh"
-        overflowY="auto"
-        p={6}
-      >
-        <DialogHeader
-          p={0}
-          mb={6}
-          display="flex"
-          justifyContent="space-between"
-          alignItems="flex-start"
-        >
-          <DialogTitle fontSize="2xl" fontWeight="800" textTransform="uppercase" flex={1} pr={4}>
-            {title}
-          </DialogTitle>
-          <chakra.button
-            type="button"
-            onClick={onClose}
-            w={10}
-            h={10}
-            border="3px solid black"
-            bg="accent"
-            color="white"
-            fontWeight="900"
-            fontSize="lg"
-            cursor="pointer"
-            boxShadow="brutal-sm"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            flexShrink={0}
-            transition="transform 0.1s ease, box-shadow 0.1s ease"
-            _hover={{ transform: "translate(-1px, -1px)", boxShadow: "brutal" }}
-            _active={{ transform: "translate(1px, 1px)", boxShadow: "none" }}
-          >
+      <DialogContent {...s.content} maxW={maxW}>
+        <DialogHeader {...s.header}>
+          <DialogTitle {...s.title}>{title}</DialogTitle>
+          <chakra.button type="button" onClick={onClose} aria-label="Close" {...s.closeBtn}>
             ✕
           </chakra.button>
         </DialogHeader>


### PR DESCRIPTION
## Summary
- Close button usa `chakra.button` com `bg: "accent"` (coral) e brutal style consistente com o restante do design system
- `title` prop aceita `ReactNode` além de string — permite passar badges e elementos compostos no header do modal
- Afeta todos os modals da aplicação (criar hábito, history, etc.)

## Test plan
- [ ] Modal de criar hábito abre e fecha corretamente com o novo botão
- [ ] Modal da página /history abre com título composto (data + badge)
- [ ] Botão fechar tem hover/active brutal correto