### PR TITLE
feat(analytics): FE-02 integrate analytics dashboard page

### DIFF
--- a/app/[locale]/(app)/analytics/page.tsx
+++ b/app/[locale]/(app)/analytics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Box, Button, Text } from "@chakra-ui/react";
+import { Alert, Box, Button } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { PageWrapper } from "@/components/PageWrapper";
 import { GlobalStatsRow } from "@/components/Analytics/GlobalStatsRow";
@@ -36,13 +36,22 @@ export default function AnalyticsPage() {
     <PageWrapper title={t("pageTitle")} loading={isLoading}>
       <Box {...s.content}>
         {isError ? (
-          <Box {...s.errorCard}>
-            <Text {...s.errorTitle}>{t("loadErrorTitle")}</Text>
-            <Text {...s.errorText}>{t("loadErrorDescription")}</Text>
-            <Button size="sm" width="fit-content" colorPalette="yellow" onClick={() => refetch()}>
-              {t("retry")}
-            </Button>
-          </Box>
+          <Alert.Root colorPalette="yellow" {...s.errorCard}>
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Title {...s.errorTitle}>{t("loadErrorTitle")}</Alert.Title>
+              <Alert.Description {...s.errorText}>{t("loadErrorDescription")}</Alert.Description>
+              <Button
+                mt={3}
+                size="sm"
+                width="fit-content"
+                colorPalette="yellow"
+                onClick={() => refetch()}
+              >
+                {t("retry")}
+              </Button>
+            </Alert.Content>
+          </Alert.Root>
         ) : (
           <>
             {data && (

--- a/app/[locale]/(app)/analytics/page.tsx
+++ b/app/[locale]/(app)/analytics/page.tsx
@@ -1,29 +1,76 @@
 "use client";
 
-import { Badge, Box, Text } from "@chakra-ui/react";
+import { useMemo, useState } from "react";
+import { Box, Button, Text } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { PageWrapper } from "@/components/PageWrapper";
-import { Link } from "@/lib/navigation";
-import { ROUTES } from "@/lib/routes";
+import { GlobalStatsRow } from "@/components/Analytics/GlobalStatsRow";
+import { HabitStatsGrid } from "@/components/Analytics/HabitStatsGrid";
+import { JournalMetrics } from "@/components/Analytics/JournalMetrics";
+import { MoodEnergyChart } from "@/components/Analytics/MoodEnergyChart";
+import { ScoreTimeline } from "@/components/Analytics/ScoreTimeline";
+import { StreakCalendar } from "@/components/Analytics/StreakCalendar";
+import { useAnalyticsSummary } from "@/lib/hooks/useAnalytics";
+import { s } from "./styles";
 
 export default function AnalyticsPage() {
-  const t = useTranslations("comingSoon");
+  const t = useTranslations("analytics");
+  const [selectedHabitId, setSelectedHabitId] = useState<string | null>(null);
+  const { data, isLoading, isError, refetch } = useAnalyticsSummary();
+
+  const habits = data?.habits ?? [];
+
+  const selectedHabit = useMemo(() => {
+    if (habits.length === 0) {
+      return null;
+    }
+
+    if (selectedHabitId == null) {
+      return habits[0] ?? null;
+    }
+
+    return habits.find((habit) => habit.id === selectedHabitId) ?? habits[0] ?? null;
+  }, [habits, selectedHabitId]);
 
   return (
-    <PageWrapper title={t("analytics.pageTitle")}>
-      <Box layerStyle="cardBrutal" bg="card" p={8} textAlign="center" maxW="480px">
-        <Badge colorPalette="yellow" mb={4} fontSize="sm" px={3} py={1}>
-          {t("badge")}
-        </Badge>
-        <Text fontWeight="bold" mb={6}>
-          {t("message")}
-        </Text>
-        <Link
-          href={ROUTES.APP_DAILY_LAB}
-          style={{ fontWeight: "bold", textDecoration: "underline" }}
-        >
-          {t("backLink")}
-        </Link>
+    <PageWrapper title={t("pageTitle")} loading={isLoading}>
+      <Box {...s.content}>
+        {isError ? (
+          <Box {...s.errorCard}>
+            <Text {...s.errorTitle}>{t("loadErrorTitle")}</Text>
+            <Text {...s.errorText}>{t("loadErrorDescription")}</Text>
+            <Button size="sm" width="fit-content" colorPalette="yellow" onClick={() => refetch()}>
+              {t("retry")}
+            </Button>
+          </Box>
+        ) : (
+          <>
+            {data && (
+              <>
+                <Box {...s.globalGrid}>
+                  <GlobalStatsRow global={data.global} />
+                </Box>
+
+                <MoodEnergyChart timeline={data.moodTimeline} />
+
+                <JournalMetrics global={data.global} />
+
+                <HabitStatsGrid
+                  habits={habits}
+                  selectedId={selectedHabit?.id ?? null}
+                  onSelect={setSelectedHabitId}
+                />
+
+                {selectedHabit && (
+                  <Box {...s.sectionGrid}>
+                    <StreakCalendar habit={selectedHabit} logs={selectedHabit.logs} />
+                    <ScoreTimeline habit={selectedHabit} />
+                  </Box>
+                )}
+              </>
+            )}
+          </>
+        )}
       </Box>
     </PageWrapper>
   );

--- a/app/[locale]/(app)/analytics/styles.ts
+++ b/app/[locale]/(app)/analytics/styles.ts
@@ -1,0 +1,47 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  content: {
+    display: "grid",
+    gap: 6,
+  },
+
+  globalGrid: {
+    display: "grid",
+    gap: 3,
+    gridTemplateColumns: {
+      base: "repeat(2, minmax(0, 1fr))",
+      lg: "repeat(4, minmax(0, 1fr))",
+    },
+  },
+
+  sectionGrid: {
+    display: "grid",
+    gap: 6,
+    gridTemplateColumns: {
+      base: "1fr",
+      xl: "minmax(0, 1.35fr) minmax(0, 1fr)",
+    },
+  },
+
+  errorCard: {
+    border: "3px solid black",
+    boxShadow: "brutal",
+    bg: "surface.coral",
+    p: 6,
+    maxW: "560px",
+    display: "grid",
+    gap: 3,
+  },
+
+  errorTitle: {
+    fontSize: "lg",
+    fontWeight: "800",
+    lineHeight: "1.2",
+  },
+
+  errorText: {
+    fontSize: "sm",
+    fontWeight: "500",
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/components/Analytics/types.ts
+++ b/components/Analytics/types.ts
@@ -1,54 +1,8 @@
-import type { PlanStatus, TargetSkill } from "@/types/habits";
-
-export interface MoodConsistencyCorrelation {
-  highMoodRate: number;
-  lowMoodRate: number;
-}
-
-export interface AnalyticsGlobalStats {
-  completionRateToday: number;
-  avgConsistencyRate: number;
-  totalJournalEntries: number;
-  totalWords: number;
-  avgWordsPerEntry: number;
-  avgMood: number | null;
-  avgEnergy: number | null;
-  aiRequestsToday: number;
-  moodConsistencyCorrelation: MoodConsistencyCorrelation | null;
-  bestPerformanceHour: string | null;
-}
-
-export interface HabitLog {
-  logDate: string;
-  completed: boolean;
-}
-
-export interface ScorePoint {
-  date: string;
-  grammarScore: number;
-  vocabularyScore: number;
-  fluencyScore: number;
-}
-
-export interface HabitStat {
-  id: string;
-  name: string;
-  icon: string;
-  color: string;
-  currentDay: number;
-  streak: number;
-  bestStreak: number;
-  consistencyRate: number;
-  totalCompletedDays: number;
-  targetSkill: TargetSkill | null;
-  planStatus: PlanStatus;
-  habitPlan: Record<string, unknown> | null;
-  logs: HabitLog[];
-  scoreTimeline: ScorePoint[] | null;
-}
-
-export interface MoodTimelineEntry {
-  date: string;
-  mood: number | null;
-  energy: number | null;
-}
+export type {
+  AnalyticsGlobalStats,
+  HabitLog,
+  HabitStat,
+  MoodConsistencyCorrelation,
+  MoodTimelineEntry,
+  ScorePoint,
+} from "@/types/analytics";

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -512,6 +512,9 @@
   },
   "analytics": {
     "pageTitle": "Analytics",
+    "loadErrorTitle": "Could not load analytics.",
+    "loadErrorDescription": "Please try again in a few seconds.",
+    "retry": "Try again",
     "noHabits": "No habits found.",
     "streak": {
       "current": "Streak",

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -512,6 +512,9 @@
   },
   "analytics": {
     "pageTitle": "Análisis",
+    "loadErrorTitle": "No se pudieron cargar los análisis.",
+    "loadErrorDescription": "Inténtalo de nuevo en unos segundos.",
+    "retry": "Intentar de nuevo",
     "noHabits": "No se encontraron hábitos.",
     "streak": {
       "current": "Racha",

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -512,6 +512,9 @@
   },
   "analytics": {
     "pageTitle": "Análises",
+    "loadErrorTitle": "Não foi possível carregar as análises.",
+    "loadErrorDescription": "Tente novamente em alguns segundos.",
+    "retry": "Tentar novamente",
     "noHabits": "Nenhum hábito encontrado.",
     "streak": {
       "current": "Sequência",

--- a/lib/analytics.service.ts
+++ b/lib/analytics.service.ts
@@ -1,0 +1,10 @@
+import { api } from "@/lib/api-client";
+import { ENDPOINTS } from "@/lib/endpoints";
+import type { AnalyticsSummary } from "@/types/analytics";
+
+export const analyticsService = {
+  async getSummary(habitId?: string): Promise<AnalyticsSummary> {
+    const params = habitId ? { habitId } : undefined;
+    return api.get<AnalyticsSummary>(ENDPOINTS.ANALYTICS.SUMMARY, { params });
+  },
+};

--- a/lib/endpoints.ts
+++ b/lib/endpoints.ts
@@ -26,6 +26,9 @@ export const ENDPOINTS = {
     HISTORY: "/journal/history",
     CREATE: "/journal/entry",
   },
+  ANALYTICS: {
+    SUMMARY: "/analytics/summary",
+  },
   AI: {
     ANALYZE: "/ai/analyze",
   },

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -5,6 +5,7 @@ import type { AnalyticsSummary } from "@/types/analytics";
 
 export function useAnalyticsSummary(habitId?: string | null) {
   const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+  const isUnauthorized = isAuthLoading || !accessToken;
 
   const query = useQuery<AnalyticsSummary, Error>({
     queryKey: ["analytics", habitId ?? "all"],
@@ -14,6 +15,9 @@ export function useAnalyticsSummary(habitId?: string | null) {
 
   return {
     ...query,
-    isLoading: isAuthLoading || query.isPending,
+    data: isUnauthorized ? null : query.data,
+    error: isUnauthorized ? null : query.error,
+    isError: isUnauthorized ? false : query.isError,
+    isLoading: isAuthLoading || query.isLoading,
   };
 }

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuthContext } from "@/lib/auth-context";
+import { analyticsService } from "@/lib/analytics.service";
+import type { AnalyticsSummary } from "@/types/analytics";
+
+export function useAnalyticsSummary(habitId?: string | null) {
+  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+
+  const query = useQuery<AnalyticsSummary, Error>({
+    queryKey: ["analytics", habitId ?? "all"],
+    queryFn: () => analyticsService.getSummary(habitId ?? undefined),
+    enabled: !isAuthLoading && !!accessToken,
+  });
+
+  return {
+    ...query,
+    isLoading: isAuthLoading || query.isPending,
+  };
+}

--- a/tests/unit/lib/endpoints.test.ts
+++ b/tests/unit/lib/endpoints.test.ts
@@ -82,4 +82,10 @@ describe("ENDPOINTS", () => {
       expect(ENDPOINTS.AI.ANALYZE).toBe("/ai/analyze");
     });
   });
+
+  describe("ANALYTICS", () => {
+    it("has the correct SUMMARY endpoint", () => {
+      expect(ENDPOINTS.ANALYTICS.SUMMARY).toBe("/analytics/summary");
+    });
+  });
 });

--- a/types/analytics.ts
+++ b/types/analytics.ts
@@ -1,0 +1,60 @@
+import type { PlanStatus, TargetSkill } from "@/types/habits";
+
+export interface MoodConsistencyCorrelation {
+  highMoodRate: number;
+  lowMoodRate: number;
+}
+
+export interface AnalyticsGlobalStats {
+  completionRateToday: number;
+  avgConsistencyRate: number;
+  totalJournalEntries: number;
+  totalWords: number;
+  avgWordsPerEntry: number;
+  avgMood: number | null;
+  avgEnergy: number | null;
+  aiRequestsToday: number;
+  moodConsistencyCorrelation: MoodConsistencyCorrelation | null;
+  bestPerformanceHour: string | null;
+}
+
+export interface HabitLog {
+  logDate: string;
+  completed: boolean;
+}
+
+export interface ScorePoint {
+  date: string;
+  grammarScore: number;
+  vocabularyScore: number;
+  fluencyScore: number;
+}
+
+export interface HabitStat {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+  currentDay: number;
+  streak: number;
+  bestStreak: number;
+  consistencyRate: number;
+  totalCompletedDays: number;
+  targetSkill: TargetSkill | null;
+  planStatus: PlanStatus;
+  habitPlan: Record<string, unknown> | null;
+  logs: HabitLog[];
+  scoreTimeline: ScorePoint[] | null;
+}
+
+export interface MoodTimelineEntry {
+  date: string;
+  mood: number | null;
+  energy: number | null;
+}
+
+export interface AnalyticsSummary {
+  habits: HabitStat[];
+  global: AnalyticsGlobalStats;
+  moodTimeline: MoodTimelineEntry[];
+}


### PR DESCRIPTION
## Summary
- replace analytics coming-soon page with the integrated dashboard layout
- add analytics API endpoint constant, typed service and react-query hook
- compose GlobalStatsRow, MoodEnergyChart, JournalMetrics, HabitStatsGrid, StreakCalendar and ScoreTimeline in analytics page
- add analytics shared types and wire component types to the shared module
- add i18n keys for analytics load error state and retry action
- address CodeRabbit feedback: semantic Alert compound on error state and loading/data safeguards in useAnalyticsSummary

## Validation
- yarn tsc --noEmit
- yarn jest tests/unit/lib/endpoints.test.ts
- pre-commit test suite (8 suites)

<- Removido import não utilizado This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

- New Features
  - Dashboard de análise totalmente funcional com estatísticas globais, gráficos de humor/energia, métricas de diário, estatísticas de hábitos e calendário de sequências.
  - Suporte para seleção de hábitos específicos e visualização de dados filtrados.
- Bug Fixes
  - Tratamento de erros implementado com opção de repetição quando os dados não carregam.
- Documentation
  - Tradução de mensagens de erro adicionada para português, espanhol e inglês.

<- Removido import não utilizado end of auto-generated comment: release notes by coderabbit.ai -->