### PR TITLE
feat: cookie consent banner and privacy policy modal

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@/lib/navigation";
+import { CookieBanner } from "@/components/CookieBanner";
 
 interface LocaleLayoutProps {
   children: React.ReactNode;
@@ -17,5 +18,10 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
 
   const messages = await getMessages();
 
-  return <NextIntlClientProvider messages={messages}>{children}</NextIntlClientProvider>;
+  return (
+    <NextIntlClientProvider messages={messages}>
+      {children}
+      <CookieBanner />
+    </NextIntlClientProvider>
+  );
 }

--- a/components/CookieBanner/PrivacyPolicyModal.tsx
+++ b/components/CookieBanner/PrivacyPolicyModal.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Box, Text } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui/button";
+import { s } from "./styles";
+
+interface PrivacyPolicyModalProps {
+  open: boolean;
+  onClose: () => void;
+  onAccept: () => void;
+}
+
+export function PrivacyPolicyModal({ open, onClose, onAccept }: PrivacyPolicyModalProps) {
+  const t = useTranslations("privacyPolicy");
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={t("title")}
+      maxW="640px"
+      footer={
+        <Box display="flex" gap={2} w="100%">
+          <Button type="button" onClick={onClose} variant="muted" flex={1}>
+            {t("close")}
+          </Button>
+          <Button type="button" onClick={onAccept} flex={1}>
+            {t("acceptAndClose")}
+          </Button>
+        </Box>
+      }
+    >
+      <Box {...s.body}>
+        <Box {...s.section}>
+          <Text {...s.sectionTitle}>{t("dataCollection")}</Text>
+          <Text {...s.sectionText}>{t("dataCollectionText")}</Text>
+        </Box>
+
+        <Box {...s.section}>
+          <Text {...s.sectionTitle}>{t("aiUsage")}</Text>
+          <Text {...s.sectionText}>{t("aiUsageText")}</Text>
+        </Box>
+
+        <Box {...s.section}>
+          <Text {...s.sectionTitle}>{t("dataStorage2")}</Text>
+          <Text {...s.sectionText}>{t("dataStorageText")}</Text>
+        </Box>
+
+        <Box {...s.section}>
+          <Text {...s.sectionTitle}>{t("userRights")}</Text>
+          <Text {...s.sectionText}>{t("userRightsText")}</Text>
+        </Box>
+
+        <Box {...s.section}>
+          <Text {...s.sectionTitle}>{t("cookies")}</Text>
+          <Text {...s.sectionText}>{t("cookiesText")}</Text>
+        </Box>
+
+        <Box {...s.section}>
+          <Text {...s.sectionTitle}>{t("contact")}</Text>
+          <Text {...s.sectionText}>{t("contactText")}</Text>
+        </Box>
+
+        <Box {...s.section}>
+          <Text {...s.sectionTitle}>{t("updates")}</Text>
+          <Text {...s.sectionText}>{t("updatesText")}</Text>
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -7,9 +7,7 @@ import { Button } from "@/components/ui";
 import { PrivacyPolicyModal } from "./PrivacyPolicyModal";
 import { useSaveConsent } from "@/lib/hooks/useConsent";
 import { s } from "./styles";
-
-export const CONSENT_KEY = "imm_consent_given";
-export const CONSENT_VERSION = "1.0";
+import { CONSENT_KEY, CONSENT_VERSION } from "@/lib/consent-constants";
 
 export interface ConsentData {
   version: string;

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -8,15 +8,19 @@ import { PrivacyPolicyModal } from "./PrivacyPolicyModal";
 import { useSaveConsent } from "@/lib/hooks/useConsent";
 import { s } from "./styles";
 
-const CONSENT_KEY = "imm_consent_given";
-const CONSENT_VERSION = "1.0";
+export const CONSENT_KEY = "imm_consent_given";
+export const CONSENT_VERSION = "1.0";
 
-interface ConsentData {
+export interface ConsentData {
   version: string;
   timestamp: string;
   accepted: boolean;
 }
 
+/**
+ * Cookie consent banner component that prompts users to accept privacy policy
+ * before using the application. Shows once and persists consent in localStorage.
+ */
 export function CookieBanner() {
   const t = useTranslations("cookieBanner");
   const [isVisible, setIsVisible] = useState(false);

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Box, Text, Link as ChakraLink } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui";
+import { PrivacyPolicyModal } from "./PrivacyPolicyModal";
+import { useSaveConsent } from "@/lib/hooks/useConsent";
+import { s } from "./styles";
+
+const CONSENT_KEY = "imm_consent_given";
+const CONSENT_VERSION = "1.0";
+
+interface ConsentData {
+  version: string;
+  timestamp: string;
+  accepted: boolean;
+}
+
+export function CookieBanner() {
+  const t = useTranslations("cookieBanner");
+  const [isVisible, setIsVisible] = useState(false);
+  const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  const { mutate: saveConsent } = useSaveConsent();
+
+  useEffect(() => {
+    const consent = localStorage.getItem(CONSENT_KEY);
+    if (!consent) {
+      setIsVisible(true);
+    }
+
+    const token = localStorage.getItem("imm_access_token");
+    setIsAuthenticated(!!token);
+  }, []);
+
+  const handleAccept = () => {
+    const consentData: ConsentData = {
+      version: CONSENT_VERSION,
+      timestamp: new Date().toISOString(),
+      accepted: true,
+    };
+    localStorage.setItem(CONSENT_KEY, JSON.stringify(consentData));
+    setIsVisible(false);
+    if (isAuthenticated) {
+      saveConsent();
+    }
+  };
+
+  const handleViewPrivacy = () => {
+    setIsVisible(false);
+    setIsPrivacyModalOpen(true);
+  };
+
+  const handlePrivacyClose = () => {
+    setIsPrivacyModalOpen(false);
+  };
+
+  const handlePrivacyAccept = () => {
+    handleAccept();
+    setIsPrivacyModalOpen(false);
+  };
+
+  if (!isVisible && !isPrivacyModalOpen) return null;
+
+  return (
+    <>
+      {isVisible && (
+        <Box {...s.overlay} role="dialog" aria-modal="true" aria-labelledby="cookie-banner-title">
+          <Box {...s.banner}>
+            <Box {...s.header}>
+              <Text {...s.headerIcon}>🍪</Text>
+              <Text id="cookie-banner-title" {...s.headerTitle}>
+                {t("title")}
+              </Text>
+            </Box>
+
+            <Box {...s.body}>
+              <Text {...s.introText}>{t("intro")}</Text>
+            </Box>
+
+            <Box {...s.footer}>
+              <Button onClick={handleAccept} w="100%">
+                {t("accept")}
+              </Button>
+              <Box {...s.links}>
+                <ChakraLink as="button" type="button" onClick={handleViewPrivacy} {...s.link}>
+                  {t("viewPrivacy")}
+                </ChakraLink>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      )}
+
+      <PrivacyPolicyModal
+        open={isPrivacyModalOpen}
+        onClose={handlePrivacyClose}
+        onAccept={handlePrivacyAccept}
+      />
+    </>
+  );
+}

--- a/components/CookieBanner/styles.ts
+++ b/components/CookieBanner/styles.ts
@@ -1,0 +1,105 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  overlay: {
+    position: "fixed",
+    inset: "0",
+    bg: "blackAlpha.700",
+    backdropFilter: "blur(4px)",
+    zIndex: 9999,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    p: 4,
+  },
+
+  banner: {
+    bg: "card",
+    border: "3px solid black",
+    boxShadow: "8px 8px 0px 0px black",
+    maxW: "500px",
+    w: "100%",
+    maxH: "90vh",
+    overflowY: "auto",
+  },
+
+  header: {
+    bg: "surface.coral",
+    p: 4,
+    borderBottom: "3px solid black",
+    display: "flex",
+    alignItems: "center",
+    gap: 3,
+  },
+
+  headerIcon: {
+    fontSize: "2xl",
+  },
+
+  headerTitle: {
+    fontSize: "lg",
+    fontWeight: "800",
+    textTransform: "uppercase",
+    letterSpacing: "0.06em",
+    lineHeight: 1.2,
+  },
+
+  body: {
+    p: 6,
+    display: "flex",
+    flexDirection: "column",
+    gap: 5,
+  },
+
+  introText: {
+    fontSize: "sm",
+    fontWeight: "600",
+    lineHeight: 1.7,
+  },
+
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+  },
+
+  sectionTitle: {
+    fontSize: "sm",
+    fontWeight: "800",
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+    color: "black",
+  },
+
+  sectionText: {
+    fontSize: "sm",
+    lineHeight: 1.6,
+    color: "black",
+  },
+
+  footer: {
+    p: 4,
+    borderTop: "3px solid black",
+    bg: "canvas",
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+  },
+
+  links: {
+    display: "flex",
+    justifyContent: "center",
+    pt: 2,
+    borderTop: "1px solid",
+    borderColor: "border",
+  },
+
+  link: {
+    fontSize: "xs",
+    fontWeight: "600",
+    textDecoration: "underline",
+    _hover: {
+      color: "secondary",
+    },
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -8,6 +8,31 @@
       "strong": "Strong"
     }
   },
+  "cookieBanner": {
+    "title": "Before you continue",
+    "intro": "To use Inside My Mind, you need to accept our privacy policy. This is necessary to save your habits, journals, and process AI analyses.",
+    "accept": "Accept and continue",
+    "viewPrivacy": "Read privacy policy"
+  },
+  "privacyPolicy": {
+    "title": "Privacy Policy & Terms",
+    "dataCollection": "1. Data Collection",
+    "dataCollectionText": "We collect information you provide directly: name, email, preferred language, and timezone. We also collect data about your habits, journals, and interactions with our AI agents to personalize your experience.",
+    "aiUsage": "2. AI Usage",
+    "aiUsageText": "We use AI (Google Gemini) to generate personalized habit plans and provide feedback on your journals. Your texts may be temporarily processed by these services for linguistic and behavioral analysis.",
+    "dataStorage2": "3. Data Storage",
+    "dataStorageText": "Your data is stored on secure servers (Supabase/PostgreSQL). We do not sell, share, or transfer your personal data to third parties.",
+    "userRights": "4. Your Rights",
+    "userRightsText": "You have the right to: access your data, correct inaccurate data, request anonymization or deletion of your data, and revoke consent. To exercise your rights, use the account deletion feature in settings.",
+    "cookies": "5. Cookies",
+    "cookiesText": "We use essential cookies for authentication and basic functionality. We do not use tracking or third-party advertising cookies.",
+    "contact": "6. Contact",
+    "contactText": "For privacy questions, contact us at: privacy@insidemymind.app",
+    "updates": "7. Updates",
+    "updatesText": "This policy may be updated periodically. We will notify you of significant changes.",
+    "acceptAndClose": "Accept and Close",
+    "close": "Close"
+  },
   "landing": {
     "seo": {
       "title": "Inside My Mind — AI-Powered Habit Tracker | 66-Day Journey",
@@ -345,6 +370,23 @@
     "toastSuccessDesc": "Your changes have been saved successfully.",
     "toastErrorTitle": "Save failed",
     "toastErrorDesc": "Could not save changes. Please try again.",
+    "accountCardTitle": "Account",
+    "accountDescription": "Deleting your account permanently removes all your data.",
+    "deleteAccount": "Delete",
+    "privacyCardTitle": "Privacy",
+    "privacyCardDescription": "Read our privacy policy to learn how we protect your data.",
+    "privacyLink": "Privacy Policy",
+    "deleteModal": {
+      "title": "Delete account",
+      "warning": "This action is permanent and irreversible. All your data will be deleted.",
+      "passwordLabel": "CURRENT PASSWORD",
+      "passwordPlaceholder": "Enter your password…",
+      "passwordRequired": "Password is required",
+      "invalidPassword": "Incorrect password",
+      "cancelBtn": "Cancel",
+      "confirmBtn": "Delete",
+      "error": "Could not delete account. Please try again."
+    },
     "timezone": {
       "america_sao_paulo": "America/São Paulo (UTC-3)",
       "america_new_york": "America/New York (UTC-5/-4)",

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -8,6 +8,31 @@
       "strong": "Fuerte"
     }
   },
+  "cookieBanner": {
+    "title": "Antes de continuar",
+    "intro": "Para usar Inside My Mind, necesitas aceptar nuestra política de privacidad. Esto es necesario para guardar tus hábitos, diarios y procesar análisis de IA.",
+    "accept": "Aceptar y continuar",
+    "viewPrivacy": "Leer política de privacidad"
+  },
+  "privacyPolicy": {
+    "title": "Política de Privacidad y Términos",
+    "dataCollection": "1. Recopilación de Datos",
+    "dataCollectionText": "Recopilamos información que proporcionas directamente: nombre, correo electrónico, idioma preferido y zona horaria. También recopilamos datos sobre tus hábitos, diarios e interacciones con nuestros agentes de IA para personalizar tu experiencia.",
+    "aiUsage": "2. Uso de IA",
+    "aiUsageText": "Utilizamos IA (Google Gemini) para generar planes de hábitos personalizados y proporcionar retroalimentación sobre tus diarios. Tus textos pueden ser procesados temporalmente por estos servicios para análisis lingüístico y conductual.",
+    "dataStorage2": "3. Almacenamiento de Datos",
+    "dataStorageText": "Tus datos se almacenan en servidores seguros (Supabase/PostgreSQL). No vendemos, compartimos ni transferimos tus datos personales a terceros.",
+    "userRights": "4. Tus Derechos",
+    "userRightsText": "Tienes derecho a: acceder a tus datos, corregir datos inexactos, solicitar anonimización o eliminación de tus datos, y revocar el consentimiento. Para ejercer tus derechos, utiliza la función de eliminación de cuenta en la configuración.",
+    "cookies": "5. Cookies",
+    "cookiesText": "Utilizamos cookies esenciales para autenticación y funcionalidad básica. No utilizamos cookies de seguimiento o publicidad de terceros.",
+    "contact": "6. Contacto",
+    "contactText": "Para preguntas sobre privacidad, contáctanos en: privacy@insidemymind.app",
+    "updates": "7. Actualizaciones",
+    "updatesText": "Esta política puede actualizarse periódicamente. Te notificaremos sobre cambios significativos.",
+    "acceptAndClose": "Aceptar y Cerrar",
+    "close": "Cerrar"
+  },
   "landing": {
     "seo": {
       "title": "Inside My Mind — Rastreador de Hábitos con IA | 66 Días",
@@ -345,6 +370,23 @@
     "toastSuccessDesc": "Tus cambios se guardaron correctamente.",
     "toastErrorTitle": "Error al guardar",
     "toastErrorDesc": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
+    "accountCardTitle": "Cuenta",
+    "accountDescription": "Eliminar tu cuenta elimina permanentemente todos tus datos.",
+    "deleteAccount": "Eliminar",
+    "privacyCardTitle": "Privacidad",
+    "privacyCardDescription": "Lee nuestra política de privacidad para saber cómo protegemos tus datos.",
+    "privacyLink": "Política de Privacidad",
+    "deleteModal": {
+      "title": "Eliminar cuenta",
+      "warning": "Esta acción es permanente e irreversible. Todos tus datos serán eliminados.",
+      "passwordLabel": "CONTRASEÑA ACTUAL",
+      "passwordPlaceholder": "Ingresa tu contraseña…",
+      "passwordRequired": "La contraseña es obligatoria",
+      "invalidPassword": "Contraseña incorrecta",
+      "cancelBtn": "Cancelar",
+      "confirmBtn": "Eliminar",
+      "error": "No se pudo eliminar la cuenta. Inténtalo de nuevo."
+    },
     "timezone": {
       "america_sao_paulo": "América/São Paulo (UTC-3)",
       "america_new_york": "América/Nueva York (UTC-5/-4)",

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -8,6 +8,31 @@
       "strong": "Forte"
     }
   },
+  "cookieBanner": {
+    "title": "Antes de continuar",
+    "intro": "Para usar o Inside My Mind, você precisa aceitar nossa política de privacidade. Isso é necessário para salvar seus hábitos, diários e processar análises de IA.",
+    "accept": "Aceitar e continuar",
+    "viewPrivacy": "Ler política de privacidade"
+  },
+  "privacyPolicy": {
+    "title": "Política de Privacidade & Termos",
+    "dataCollection": "1. Coleta de Dados",
+    "dataCollectionText": "Coletamos informações que você nos fornece diretamente: nome, e-mail, idioma preferido e fuso horário. Também coletamos dados sobre seus hábitos, diários e interações com nossos agentes de IA para personalizar sua experiência.",
+    "aiUsage": "2. Uso de IA",
+    "aiUsageText": "Utilizamos IA (Google Gemini) para gerar planos de hábito personalizados e fornecer feedback sobre seus diários. Seus textos podem ser processados temporariamente por esses serviços para análise linguística e comportamental.",
+    "dataStorage2": "3. Armazenamento de Dados",
+    "dataStorageText": "Seus dados são armazenados em servidores seguros (Supabase/PostgreSQL). Não vendemos, compartilhamos ou transferimos seus dados pessoais para terceiros.",
+    "userRights": "4. Seus Direitos (LGPD)",
+    "userRightsText": "Você tem direito a: acessar seus dados, corrigir dados incorretos, solicitar anonimização ou exclusão dos seus dados, e revogar consentimento. Para exercer seus direitos, utilize a função de exclusão de conta nas configurações.",
+    "cookies": "5. Cookies",
+    "cookiesText": "Utilizamos cookies essenciais para autenticação e funcionamento básico. Não utilizamos cookies de rastreamento ou publicidade de terceiros.",
+    "contact": "6. Contato",
+    "contactText": "Para dúvidas sobre privacidade, entre em contato pelo e-mail: privacy@insidemymind.app",
+    "updates": "7. Atualizações",
+    "updatesText": "Esta política pode ser atualizada periodicamente. Notificaremos sobre mudanças significativas.",
+    "acceptAndClose": "Aceitar e Fechar",
+    "close": "Fechar"
+  },
   "landing": {
     "seo": {
       "title": "Inside My Mind — Rastreador de Hábitos com IA | 66 Dias",
@@ -345,6 +370,23 @@
     "toastSuccessDesc": "Suas alterações foram salvas com sucesso.",
     "toastErrorTitle": "Erro ao salvar",
     "toastErrorDesc": "Não foi possível salvar as alterações. Tente novamente.",
+    "accountCardTitle": "Conta",
+    "accountDescription": "Excluir sua conta remove todos os seus dados permanentemente.",
+    "deleteAccount": "Excluir",
+    "privacyCardTitle": "Privacidade",
+    "privacyCardDescription": "Leia nossa política de privacidade para saber como protegemos seus dados.",
+    "privacyLink": "Política de Privacidade",
+    "deleteModal": {
+      "title": "Excluir conta",
+      "warning": "Esta ação é permanente e irreversível. Todos os seus dados serão apagados.",
+      "passwordLabel": "SENHA ATUAL",
+      "passwordPlaceholder": "Digite sua senha…",
+      "passwordRequired": "A senha é obrigatória",
+      "invalidPassword": "Senha incorreta",
+      "cancelBtn": "Cancelar",
+      "confirmBtn": "Excluir",
+      "error": "Não foi possível excluir a conta. Tente novamente."
+    },
     "timezone": {
       "america_sao_paulo": "América/São Paulo (UTC-3)",
       "america_new_york": "América/Nova York (UTC-5/-4)",

--- a/lib/consent-constants.ts
+++ b/lib/consent-constants.ts
@@ -1,0 +1,2 @@
+export const CONSENT_KEY = "imm_consent_given";
+export const CONSENT_VERSION = "1.0";

--- a/lib/consent.service.ts
+++ b/lib/consent.service.ts
@@ -1,0 +1,24 @@
+import { api } from "./api-client";
+import { ENDPOINTS } from "./endpoints";
+
+export type ConsentType = "privacy_policy" | "terms_of_use" | "cookie_consent";
+
+export interface ConsentResponse {
+  success: boolean;
+  consent: {
+    type: string;
+    version: string;
+    accepted: boolean;
+    createdAt: string;
+  };
+}
+
+export const consentService = {
+  async saveConsent(type: ConsentType): Promise<ConsentResponse> {
+    return api.post<ConsentResponse>(ENDPOINTS.CONSENTS.SAVE, { type });
+  },
+
+  async getConsents(): Promise<ConsentResponse[]> {
+    return api.get<ConsentResponse[]>(ENDPOINTS.CONSENTS.LIST);
+  },
+};

--- a/lib/endpoints.ts
+++ b/lib/endpoints.ts
@@ -8,7 +8,12 @@ export const ENDPOINTS = {
   USER: {
     ME: "/users/me",
     UPDATE: "/users/me",
+    DELETE: "/users/me",
     AVATAR_UPLOAD_URL: "/users/me/avatar-upload-url",
+  },
+  CONSENTS: {
+    SAVE: "/consents",
+    LIST: "/consents",
   },
   HABITS: {
     LIST: "/habits",

--- a/lib/hooks/useConsent.ts
+++ b/lib/hooks/useConsent.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import { consentService } from "@/lib/consent.service";
+
+export function useSaveConsent() {
+  return useMutation({
+    mutationFn: () =>
+      Promise.all([
+        consentService.saveConsent("cookie_consent"),
+        consentService.saveConsent("privacy_policy"),
+        consentService.saveConsent("terms_of_use"),
+      ]),
+  });
+}

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { CONSENT_KEY, CONSENT_VERSION } from "@/components/CookieBanner";
+import { CONSENT_KEY, CONSENT_VERSION } from "@/lib/consent-constants";
 
 const CONSENT_DATA = JSON.stringify({
   version: CONSENT_VERSION,
@@ -17,6 +17,8 @@ async function setConsent(page: Page) {
     key: CONSENT_KEY,
     value: CONSENT_DATA,
   });
+  await page.reload();
+  await page.waitForLoadState("networkidle");
 }
 
 test.describe("Landing page", () => {
@@ -27,19 +29,17 @@ test.describe("Landing page", () => {
 
   test("navigate to login page from header", async ({ page }) => {
     await setConsent(page);
-    await page
-      .getByRole("link", { name: /entrar|log in/i })
-      .first()
-      .click();
+    const link = page.getByRole("link", { name: /entrar|log in/i }).first();
+    await link.waitFor({ state: "visible" });
+    await link.click();
     await expect(page).toHaveURL(/\/login/);
   });
 
   test("navigate to register page from CTA", async ({ page }) => {
     await setConsent(page);
-    await page
-      .getByRole("link", { name: /criar.*plano|create.*plan|crear.*plan/i })
-      .first()
-      .click();
+    const link = page.getByRole("link", { name: /criar.*plano|create.*plan|crear.*plan/i }).first();
+    await link.waitFor({ state: "visible" });
+    await link.click();
     await expect(page).toHaveURL(/\/register/);
   });
 });

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,12 +1,16 @@
 import { test, expect, type Page } from "@playwright/test";
+import { CONSENT_KEY, CONSENT_VERSION } from "@/components/CookieBanner";
 
-const CONSENT_KEY = "imm_consent_given";
 const CONSENT_DATA = JSON.stringify({
-  version: "1.0",
+  version: CONSENT_VERSION,
   timestamp: new Date().toISOString(),
   accepted: true,
 });
 
+/**
+ * Sets cookie consent in localStorage before navigation.
+ * Prevents the CookieBanner from blocking interactions.
+ */
 async function setConsent(page: Page) {
   await page.goto("/pt-BR/");
   await page.evaluate(({ key, value }) => localStorage.setItem(key, value), {
@@ -42,12 +46,14 @@ test.describe("Landing page", () => {
 
 test.describe("Auth pages", () => {
   test("login page renders the form", async ({ page }) => {
+    await setConsent(page);
     await page.goto("/pt-BR/login");
     await expect(page.getByRole("textbox", { name: /e-mail|email/i })).toBeVisible();
     await expect(page.getByRole("textbox", { name: /senha|password/i })).toBeVisible();
   });
 
   test("register page renders the form", async ({ page }) => {
+    await setConsent(page);
     await page.goto("/pt-BR/register");
     await expect(page.getByRole("textbox", { name: /e-mail|email/i })).toBeVisible();
   });

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,4 +1,19 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+const CONSENT_KEY = "imm_consent_given";
+const CONSENT_DATA = JSON.stringify({
+  version: "1.0",
+  timestamp: new Date().toISOString(),
+  accepted: true,
+});
+
+async function setConsent(page: Page) {
+  await page.goto("/pt-BR/");
+  await page.evaluate(({ key, value }) => localStorage.setItem(key, value), {
+    key: CONSENT_KEY,
+    value: CONSENT_DATA,
+  });
+}
 
 test.describe("Landing page", () => {
   test("loads and shows the main heading", async ({ page }) => {
@@ -7,7 +22,7 @@ test.describe("Landing page", () => {
   });
 
   test("navigate to login page from header", async ({ page }) => {
-    await page.goto("/pt-BR/");
+    await setConsent(page);
     await page
       .getByRole("link", { name: /entrar|log in/i })
       .first()
@@ -16,7 +31,7 @@ test.describe("Landing page", () => {
   });
 
   test("navigate to register page from CTA", async ({ page }) => {
-    await page.goto("/pt-BR/");
+    await setConsent(page);
     await page
       .getByRole("link", { name: /criar.*plano|create.*plan|crear.*plan/i })
       .first()


### PR DESCRIPTION
## Summary

- Add CookieBanner component for LGPD cookie consent
- Add PrivacyPolicyModal with full privacy policy content
- Add consent.service.ts for API communication
- Add useSaveConsent hook (TanStack Query)
- Add i18n strings for pt-BR, en-US, es-ES

## Changes

- `components/CookieBanner/` - Cookie consent banner and privacy policy modal
- `lib/consent.service.ts` - Consent API service
- `lib/hooks/useConsent.ts` - TanStack Query mutation hook
- i18n messages for all three languages

## Testing

- All 75 tests pass
- Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Novas Funcionalidades**
  * Banner de cookies visível no layout com aceitar consentimento e link para política de privacidade.
  * Modal de política de privacidade com seções detalhadas (coleta de dados, uso de IA, armazenamento, direitos, cookies, contato, atualizações).
  * Persistência do consentimento e envio do consentimento ao backend quando autenticado.

* **Localização**
  * Traduções adicionadas para en-US, es-ES e pt-BR para todo o fluxo de consentimento e textos de privacidade.

* **Testes**
  * Atualizados testes de e2e para pré-definir consentimento ao navegar nas páginas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->