### PR TITLE
fix: call GET /consents before showing cookie banner

### DIFF
--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -10,10 +10,6 @@ import { s } from "./styles";
 import { hasLocalConsent, setLocalConsent } from "@/lib/consent-constants";
 import { useAuthContext } from "@/lib/auth-context";
 
-/**
- * Cookie consent banner component that prompts users to accept privacy policy
- * before using the application. Shows once and persists consent in localStorage.
- */
 export function CookieBanner() {
   const t = useTranslations("cookieBanner");
   const { isAuthenticated, isLoading: isAuthLoading } = useAuthContext();

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -7,37 +7,13 @@ import { Button } from "@/components/ui";
 import { PrivacyPolicyModal } from "./PrivacyPolicyModal";
 import { useGetConsents, useSaveConsent } from "@/lib/hooks/useConsent";
 import { s } from "./styles";
-import { CONSENT_KEY, CONSENT_VERSION } from "@/lib/consent-constants";
+import { hasLocalConsent, setLocalConsent } from "@/lib/consent-constants";
 import { useAuthContext } from "@/lib/auth-context";
 
-export interface ConsentData {
-  version: string;
-  timestamp: string;
-  accepted: boolean;
-}
-
-function hasLocalConsent(): boolean {
-  if (typeof window === "undefined") return false;
-  const stored = localStorage.getItem(CONSENT_KEY);
-  if (!stored) return false;
-
-  try {
-    const parsed = JSON.parse(stored) as ConsentData;
-    return parsed.version === CONSENT_VERSION;
-  } catch {
-    return stored === CONSENT_VERSION;
-  }
-}
-
-function setLocalConsent(): void {
-  const consentData: ConsentData = {
-    version: CONSENT_VERSION,
-    timestamp: new Date().toISOString(),
-    accepted: true,
-  };
-  localStorage.setItem(CONSENT_KEY, JSON.stringify(consentData));
-}
-
+/**
+ * Cookie consent banner component that prompts users to accept privacy policy
+ * before using the application. Shows once and persists consent in localStorage.
+ */
 export function CookieBanner() {
   const t = useTranslations("cookieBanner");
   const { isAuthenticated, isLoading: isAuthLoading } = useAuthContext();

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -18,7 +18,15 @@ export interface ConsentData {
 
 function hasLocalConsent(): boolean {
   if (typeof window === "undefined") return false;
-  return !!localStorage.getItem(CONSENT_KEY);
+  const stored = localStorage.getItem(CONSENT_KEY);
+  if (!stored) return false;
+
+  try {
+    const parsed = JSON.parse(stored) as ConsentData;
+    return parsed.version === CONSENT_VERSION;
+  } catch {
+    return stored === CONSENT_VERSION;
+  }
 }
 
 function setLocalConsent(): void {

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -32,7 +32,7 @@ function setLocalConsent(): void {
 
 export function CookieBanner() {
   const t = useTranslations("cookieBanner");
-  const { isAuthenticated } = useAuthContext();
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuthContext();
   const [isVisible, setIsVisible] = useState(false);
   const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false);
 
@@ -40,13 +40,13 @@ export function CookieBanner() {
   const { mutate: saveConsent, isPending: isSavingConsent } = useSaveConsent();
 
   useEffect(() => {
-    if (isLoadingConsents) return;
+    if (isLoadingConsents || isAuthLoading) return;
 
     const hasConsent = hasLocalConsent() || (consentsData?.length ?? 0) > 0;
     if (!hasConsent) {
       setIsVisible(true);
     }
-  }, [isLoadingConsents, consentsData]);
+  }, [isLoadingConsents, consentsData, isAuthLoading]);
 
   const handleAccept = () => {
     setLocalConsent();

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -5,9 +5,10 @@ import { Box, Text, Link as ChakraLink } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui";
 import { PrivacyPolicyModal } from "./PrivacyPolicyModal";
-import { useSaveConsent } from "@/lib/hooks/useConsent";
+import { useGetConsents, useSaveConsent } from "@/lib/hooks/useConsent";
 import { s } from "./styles";
 import { CONSENT_KEY, CONSENT_VERSION } from "@/lib/consent-constants";
+import { useAuthContext } from "@/lib/auth-context";
 
 export interface ConsentData {
   version: string;
@@ -15,35 +16,40 @@ export interface ConsentData {
   accepted: boolean;
 }
 
-/**
- * Cookie consent banner component that prompts users to accept privacy policy
- * before using the application. Shows once and persists consent in localStorage.
- */
+function hasLocalConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!localStorage.getItem(CONSENT_KEY);
+}
+
+function setLocalConsent(): void {
+  const consentData: ConsentData = {
+    version: CONSENT_VERSION,
+    timestamp: new Date().toISOString(),
+    accepted: true,
+  };
+  localStorage.setItem(CONSENT_KEY, JSON.stringify(consentData));
+}
+
 export function CookieBanner() {
   const t = useTranslations("cookieBanner");
+  const { isAuthenticated } = useAuthContext();
   const [isVisible, setIsVisible] = useState(false);
   const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  const { mutate: saveConsent } = useSaveConsent();
+  const { data: consentsData, isLoading: isLoadingConsents } = useGetConsents();
+  const { mutate: saveConsent, isPending: isSavingConsent } = useSaveConsent();
 
   useEffect(() => {
-    const consent = localStorage.getItem(CONSENT_KEY);
-    if (!consent) {
+    if (isLoadingConsents) return;
+
+    const hasConsent = hasLocalConsent() || (consentsData?.length ?? 0) > 0;
+    if (!hasConsent) {
       setIsVisible(true);
     }
-
-    const token = localStorage.getItem("imm_access_token");
-    setIsAuthenticated(!!token);
-  }, []);
+  }, [isLoadingConsents, consentsData]);
 
   const handleAccept = () => {
-    const consentData: ConsentData = {
-      version: CONSENT_VERSION,
-      timestamp: new Date().toISOString(),
-      accepted: true,
-    };
-    localStorage.setItem(CONSENT_KEY, JSON.stringify(consentData));
+    setLocalConsent();
     setIsVisible(false);
     if (isAuthenticated) {
       saveConsent();
@@ -83,7 +89,7 @@ export function CookieBanner() {
             </Box>
 
             <Box {...s.footer}>
-              <Button onClick={handleAccept} w="100%">
+              <Button onClick={handleAccept} w="100%" loading={isSavingConsent}>
                 {t("accept")}
               </Button>
               <Box {...s.links}>

--- a/lib/consent-constants.ts
+++ b/lib/consent-constants.ts
@@ -1,2 +1,30 @@
 export const CONSENT_KEY = "imm_consent_given";
 export const CONSENT_VERSION = "1.0";
+
+export interface ConsentData {
+  version: string;
+  timestamp: string;
+  accepted: boolean;
+}
+
+export function hasLocalConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  const stored = localStorage.getItem(CONSENT_KEY);
+  if (!stored) return false;
+
+  try {
+    const parsed = JSON.parse(stored) as ConsentData;
+    return parsed.version === CONSENT_VERSION;
+  } catch {
+    return stored === CONSENT_VERSION;
+  }
+}
+
+export function setLocalConsent(): void {
+  const consentData: ConsentData = {
+    version: CONSENT_VERSION,
+    timestamp: new Date().toISOString(),
+    accepted: true,
+  };
+  localStorage.setItem(CONSENT_KEY, JSON.stringify(consentData));
+}

--- a/lib/hooks/useConsent.ts
+++ b/lib/hooks/useConsent.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { consentService } from "@/lib/consent.service";
 import { toaster } from "@/components/ui/toaster";
@@ -20,6 +20,7 @@ export function useGetConsents() {
 export function useSaveConsent(options?: { onError?: (_error: Error) => void }) {
   const t = useTranslations("errors");
   const { translateError } = useTranslatedError();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: () =>
@@ -28,6 +29,9 @@ export function useSaveConsent(options?: { onError?: (_error: Error) => void }) 
         consentService.saveConsent("privacy_policy"),
         consentService.saveConsent("terms_of_use"),
       ]),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["consents"] });
+    },
     onError: (error: Error) => {
       toaster.create({
         title: t("title"),

--- a/lib/hooks/useConsent.ts
+++ b/lib/hooks/useConsent.ts
@@ -3,13 +3,17 @@ import { useTranslations } from "next-intl";
 import { consentService } from "@/lib/consent.service";
 import { toaster } from "@/components/ui/toaster";
 import { useTranslatedError } from "./useTranslatedError";
+import { useAuthContext } from "@/lib/auth-context";
 
 export function useGetConsents() {
+  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+
   return useQuery({
     queryKey: ["consents"],
     queryFn: () => consentService.getConsents(),
     retry: false,
     staleTime: Infinity,
+    enabled: !isAuthLoading && !!accessToken,
   });
 }
 

--- a/lib/hooks/useConsent.ts
+++ b/lib/hooks/useConsent.ts
@@ -1,8 +1,17 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { consentService } from "@/lib/consent.service";
 import { toaster } from "@/components/ui/toaster";
 import { useTranslatedError } from "./useTranslatedError";
+
+export function useGetConsents() {
+  return useQuery({
+    queryKey: ["consents"],
+    queryFn: () => consentService.getConsents(),
+    retry: false,
+    staleTime: Infinity,
+  });
+}
 
 export function useSaveConsent(options?: { onError?: (_error: Error) => void }) {
   const t = useTranslations("errors");


### PR DESCRIPTION
## Summary
- Add `useGetConsents` query hook to fetch user consents from API
- CookieBanner now checks API consent status when user is authenticated
- Only shows banner if no consent exists (both localStorage AND API check)
- Fix POST call to save consent when accepting
- Add loading state to accept button

## Changes
- `lib/hooks/useConsent.ts`: Added `useGetConsents` query hook
- `components/CookieBanner/index.tsx`: Refactored to use API consent check

## Testing
- Build passes
- Unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * O banner de cookies agora considera tanto preferências locais quanto consentimentos do servidor antes de ser exibido.
  * O banner aguarda estados de carregamento necessários antes de decidir a visibilidade.
  * Ao aceitar, o consentimento é persistido localmente e só é enviado ao servidor quando o usuário está autenticado.
  * O botão "Aceitar" mostra indicador de carregamento durante a operação de salvamento.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->