### PR TITLE
fix: prevent unnecessary auth refresh calls

### DIFF
--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -31,7 +31,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const existingToken = api.getToken();
     if (existingToken) {
       setAccessTokenState(existingToken);
-      setIsLoading(false);
       authService
         .refresh()
         .then((data) => {
@@ -42,21 +41,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .catch(() => {
           api.removeToken();
           setAccessTokenState(null);
+        })
+        .finally(() => {
+          setIsLoading(false);
         });
       return;
     }
 
-    authService
-      .refresh()
-      .then((data) => {
-        api.setToken(data.token);
-        setAccessTokenState(data.token);
-        setUserState(data.user);
-      })
-      .catch((_error) => {})
-      .finally(() => {
-        setIsLoading(false);
-      });
+    const hasRefreshToken = document.cookie.includes("refreshToken=");
+    if (hasRefreshToken) {
+      authService
+        .refresh()
+        .then((data) => {
+          api.setToken(data.token);
+          setAccessTokenState(data.token);
+          setUserState(data.user);
+        })
+        .catch((_error) => {})
+        .finally(() => {
+          setIsLoading(false);
+        });
+    } else {
+      setIsLoading(false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -8,6 +8,11 @@ import { authService } from "@/lib/auth.service";
 import type { AuthResponse, LoginInput, RegisterInput, User } from "@/types/auth";
 import { isAuthRoute } from "@/lib/routing-utils";
 
+function hasRefreshTokenCookie(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.cookie.split(";").some((cookie) => cookie.trim().startsWith("refreshToken="));
+}
+
 /**
  * Provedor de autenticação que gerencia estado global de usuário e token.
  * Tenta refresh automático ao carregar e fornece funções de login/logout/register.
@@ -48,7 +53,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    const hasRefreshToken = document.cookie.includes("refreshToken=");
+    const hasRefreshToken = hasRefreshTokenCookie();
     if (hasRefreshToken) {
       authService
         .refresh()

--- a/tests/unit/lib/auth-context.test.tsx
+++ b/tests/unit/lib/auth-context.test.tsx
@@ -15,6 +15,12 @@ jest.mock("@/lib/auth.service", () => ({
   },
 }));
 
+Object.defineProperty(document, "cookie", {
+  value: "",
+  writable: true,
+  configurable: true,
+});
+
 jest.mock("@/lib/api-client", () => ({
   api: {
     setToken: jest.fn(),
@@ -43,14 +49,12 @@ beforeEach(() => {
 
 describe("AuthProvider", () => {
   describe("initial state", () => {
-    it("starts with isLoading true and becomes false after rehydration attempt", async () => {
+    it("starts with isLoading false when no token and no refresh cookie", async () => {
       const { result } = renderHook(() => useAuthContext(), { wrapper });
 
-      expect(result.current.isLoading).toBe(true);
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.accessToken).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
     });
 
     it("has no user and no token when refresh fails", async () => {
@@ -65,6 +69,11 @@ describe("AuthProvider", () => {
 
     it("rehydrates user from a valid refresh token cookie on mount", async () => {
       mockAuthService.refresh.mockResolvedValue(mockAuthResponse);
+      Object.defineProperty(document, "cookie", {
+        value: "refreshToken=test-refresh-token",
+        writable: true,
+        configurable: true,
+      });
 
       const { result } = renderHook(() => useAuthContext(), { wrapper });
 
@@ -74,6 +83,12 @@ describe("AuthProvider", () => {
       expect(result.current.user).toEqual(mockAuthResponse.user);
       expect(result.current.isAuthenticated).toBe(true);
       expect(mockApi.setToken).toHaveBeenCalledWith(mockAuthResponse.token);
+
+      Object.defineProperty(document, "cookie", {
+        value: "",
+        writable: true,
+        configurable: true,
+      });
     });
 
     it("skips loading block and hydrates user via background refresh when token already in memory", async () => {
@@ -82,11 +97,10 @@ describe("AuthProvider", () => {
 
       const { result } = renderHook(() => useAuthContext(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-
       expect(result.current.accessToken).toBe("existing-token");
       expect(result.current.isAuthenticated).toBe(true);
 
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
       await waitFor(() => expect(result.current.user).toEqual(mockAuthResponse.user));
       expect(result.current.accessToken).toBe(mockAuthResponse.token);
 
@@ -99,9 +113,10 @@ describe("AuthProvider", () => {
 
       const { result } = renderHook(() => useAuthContext(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.accessToken).toBe("existing-token");
+      expect(result.current.isAuthenticated).toBe(true);
 
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
       await waitFor(() => expect(result.current.accessToken).toBeNull());
       expect(result.current.isAuthenticated).toBe(false);
       expect(result.current.user).toBeNull();

--- a/tests/unit/lib/auth-context.test.tsx
+++ b/tests/unit/lib/auth-context.test.tsx
@@ -42,9 +42,22 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return <AuthProvider>{children}</AuthProvider>;
 }
 
+function clearCookies(): void {
+  Object.defineProperty(document, "cookie", {
+    value: "",
+    writable: true,
+    configurable: true,
+  });
+}
+
 beforeEach(() => {
+  clearCookies();
   jest.clearAllMocks();
   mockAuthService.refresh.mockRejectedValue(new Error("No session"));
+});
+
+afterEach(() => {
+  clearCookies();
 });
 
 describe("AuthProvider", () => {
@@ -83,12 +96,6 @@ describe("AuthProvider", () => {
       expect(result.current.user).toEqual(mockAuthResponse.user);
       expect(result.current.isAuthenticated).toBe(true);
       expect(mockApi.setToken).toHaveBeenCalledWith(mockAuthResponse.token);
-
-      Object.defineProperty(document, "cookie", {
-        value: "",
-        writable: true,
-        configurable: true,
-      });
     });
 
     it("skips loading block and hydrates user via background refresh when token already in memory", async () => {


### PR DESCRIPTION
## Summary
- Only call `/auth/refresh` if there's an existing access token OR a refresh token cookie
- Prevents unnecessary refresh calls on every page load for unauthenticated users

## Changes
- `providers/AuthProvider.tsx`: Check for refresh token cookie before calling refresh