### PR TITLE
fix: sync consent to server and fix ConsentResponse type

### DIFF
--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -22,11 +22,18 @@ export function CookieBanner() {
   useEffect(() => {
     if (isLoadingConsents || isAuthLoading) return;
 
-    const hasConsent = hasLocalConsent() || (consentsData?.length ?? 0) > 0;
-    if (!hasConsent) {
+    const localConsent = hasLocalConsent();
+    const serverConsentCount = consentsData?.length ?? 0;
+
+    if (!localConsent && serverConsentCount === 0) {
       setIsVisible(true);
+      return;
     }
-  }, [isLoadingConsents, consentsData, isAuthLoading]);
+
+    if (isAuthenticated && localConsent && serverConsentCount === 0) {
+      saveConsent();
+    }
+  }, [isLoadingConsents, consentsData, isAuthLoading, isAuthenticated, saveConsent]);
 
   const handleAccept = () => {
     setLocalConsent();

--- a/lib/consent.service.ts
+++ b/lib/consent.service.ts
@@ -4,13 +4,10 @@ import { ENDPOINTS } from "./endpoints";
 export type ConsentType = "privacy_policy" | "terms_of_use" | "cookie_consent";
 
 export interface ConsentResponse {
-  success: boolean;
-  consent: {
-    type: string;
-    version: string;
-    accepted: boolean;
-    createdAt: string;
-  };
+  id: string;
+  type: ConsentType;
+  version: string;
+  acceptedAt: string;
 }
 
 export const consentService = {


### PR DESCRIPTION
## Summary

- **Endpoints não eram chamados:** usuário não autenticado aceita o banner → localStorage salvo, sem chamada à API. Ao fazer login depois, `GET /consents` retorna vazio mas `hasLocalConsent()` é true → banner não reaparece → POST nunca acontece. Resultado: servidor nunca recebe o consentimento
- **`ConsentResponse` type errado:** shape `{ success, consent: { ... } }` não correspondia ao retorno real da API `{ id, type, version, acceptedAt }`

## Changes

- `lib/consent.service.ts`: corrige `ConsentResponse` para `{ id, type, version, acceptedAt }`
- `components/CookieBanner/index.tsx`: adiciona sync automático — quando usuário autenticado tem consentimento local mas não tem registro no servidor, chama `saveConsent()` silenciosamente

## Test plan

- [ ] Aceitar o banner sem estar logado → fazer login → confirmar que POST `/api/consents` é chamado automaticamente
- [ ] Aceitar o banner já logado → confirmar que POST `/api/consents` é chamado imediatamente
- [ ] Confirmar que o banner não reaparece após aceitar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * Comportamento aprimorado do banner de consentimento que agora exibe apenas quando necessário, oferecendo uma experiência mais limpa ao usuário.
  * Salvamento automático de consentimento para usuários autenticados em situações aplicáveis, simplificando o processo de gerenciamento de preferências.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->