### PR TITLE
fix: consent sync after login

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@/lib/navigation";
 import { CookieBanner } from "@/components/CookieBanner";
+import { ConsentSync } from "@/components/ConsentSync";
 
 interface LocaleLayoutProps {
   children: React.ReactNode;
@@ -22,6 +23,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
     <NextIntlClientProvider messages={messages}>
       {children}
       <CookieBanner />
+      <ConsentSync />
     </NextIntlClientProvider>
   );
 }

--- a/components/ConsentSync/index.tsx
+++ b/components/ConsentSync/index.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useConsentSync } from "@/lib/hooks/useConsentSync";
+
+export function ConsentSync() {
+  useConsentSync();
+  return null;
+}

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -21,7 +21,11 @@ export function CookieBanner() {
 
   useEffect(() => {
     if (isAuthLoading || isLoadingConsents) return;
-    if (hasLocalConsent() || (consentsData?.length ?? 0) > 0) return;
+    if ((consentsData?.length ?? 0) > 0) {
+      if (!hasLocalConsent()) setLocalConsent();
+      return;
+    }
+    if (hasLocalConsent()) return;
     setIsVisible(true);
   }, [isAuthLoading, isLoadingConsents, consentsData]);
 

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -20,20 +20,10 @@ export function CookieBanner() {
   const { mutate: saveConsent, isPending: isSavingConsent } = useSaveConsent();
 
   useEffect(() => {
-    if (isLoadingConsents || isAuthLoading) return;
-
-    const localConsent = hasLocalConsent();
-    const serverConsentCount = consentsData?.length ?? 0;
-
-    if (!localConsent && serverConsentCount === 0) {
-      setIsVisible(true);
-      return;
-    }
-
-    if (isAuthenticated && localConsent && serverConsentCount === 0) {
-      saveConsent();
-    }
-  }, [isLoadingConsents, consentsData, isAuthLoading, isAuthenticated, saveConsent]);
+    if (isAuthLoading || isLoadingConsents) return;
+    if (hasLocalConsent() || (consentsData?.length ?? 0) > 0) return;
+    setIsVisible(true);
+  }, [isAuthLoading, isLoadingConsents, consentsData]);
 
   const handleAccept = () => {
     setLocalConsent();

--- a/lib/hooks/useConsentSync.ts
+++ b/lib/hooks/useConsentSync.ts
@@ -6,7 +6,11 @@ import { hasLocalConsent } from "@/lib/consent-constants";
 export function useConsentSync() {
   const { isAuthenticated, isLoading: isAuthLoading } = useAuthContext();
   const { data: consentsData, isLoading: isLoadingConsents } = useGetConsents();
-  const { mutate: saveConsent } = useSaveConsent();
+  const { mutate: saveConsent } = useSaveConsent({
+    onError: () => {
+      hasSynced.current = false;
+    },
+  });
   const hasSynced = useRef(false);
 
   useEffect(() => {

--- a/lib/hooks/useConsentSync.ts
+++ b/lib/hooks/useConsentSync.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "react";
+import { useAuthContext } from "@/lib/auth-context";
+import { useGetConsents, useSaveConsent } from "./useConsent";
+import { hasLocalConsent } from "@/lib/consent-constants";
+
+export function useConsentSync() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuthContext();
+  const { data: consentsData, isLoading: isLoadingConsents } = useGetConsents();
+  const { mutate: saveConsent } = useSaveConsent();
+  const hasSynced = useRef(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      hasSynced.current = false;
+      return;
+    }
+
+    if (isAuthLoading || isLoadingConsents) return;
+    if (hasSynced.current) return;
+    if (!hasLocalConsent()) return;
+    if ((consentsData?.length ?? 0) > 0) {
+      hasSynced.current = true;
+      return;
+    }
+
+    hasSynced.current = true;
+    saveConsent();
+  }, [isAuthLoading, isLoadingConsents, isAuthenticated, consentsData, saveConsent]);
+}


### PR DESCRIPTION
## Summary
- Cria `useConsentSync`: hook dedicado que monitora o estado de autenticação e faz POST /consents automaticamente na primeira vez que o usuário loga, se houver consent no localStorage sem registro no servidor
- Cria `ConsentSync`: componente invisível montado no locale layout que executa o hook
- Simplifica `CookieBanner`: responsabilidade única — mostrar/esconder banner e aceitar consent imediato (localStorage + POST se já autenticado)

## Fluxo após essa mudança
1. Usuário anônimo vê o banner → aceita → salva localStorage (sem request — sem user_id, impossível vincular ao servidor)
2. Usuário faz login → `useConsentSync` detecta: autenticado + consent local + sem registro no servidor → dispara POST /consents automaticamente
3. Se usuário já estava logado ao aceitar → POST imediato no `handleAccept`

## Test plan
- [ ] Usuário anônimo aceita banner → verificar que só salva localStorage, sem request na aba Network
- [ ] Usuário anônimo aceita → faz login → verificar POST /consents na aba Network
- [ ] Usuário já logado aceita banner → verificar POST /consents imediato
- [ ] Recarregar página depois → banner não aparece mais

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * Aprimorado o gerenciamento de consentimento do usuário com sincronização automática entre armazenamento local e servidor, garantindo que suas preferências de privacidade sejam mantidas de forma consistente em todos os dispositivos e sessões.
  * Simplificado a lógica de exibição do aviso de cookies para uma experiência mais clara e intuitiva ao gerenciar suas escolhas de consentimento e privacidade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->