### PR TITLE
feat(auth): update register and login pages for email verification flow

### DIFF
--- a/app/[locale]/(auth)/auth.styles.ts
+++ b/app/[locale]/(auth)/auth.styles.ts
@@ -56,6 +56,10 @@ export const sharedAuthStyles = {
   submitBtn: {
     width: "100%",
   },
+  forgotPasswordWrapper: {
+    alignSelf: "flex-end",
+    mt: -2,
+  },
   footerText: {
     textAlign: "center",
     fontSize: "sm",
@@ -75,4 +79,10 @@ export const footerLinkStyle: CSSProperties = {
   color: "black",
   textDecoration: "underline",
   textUnderlineOffset: "4px",
+};
+
+export const forgotPasswordLinkStyle: CSSProperties = {
+  fontSize: "0.875rem",
+  color: "hsl(0, 0%, 30%)",
+  textDecoration: "none",
 };

--- a/app/[locale]/(auth)/auth.styles.ts
+++ b/app/[locale]/(auth)/auth.styles.ts
@@ -83,6 +83,6 @@ export const footerLinkStyle: CSSProperties = {
 
 export const forgotPasswordLinkStyle: CSSProperties = {
   fontSize: "0.875rem",
-  color: "hsl(0, 0%, 30%)",
+  color: "var(--chakra-colors-muted-fg)",
   textDecoration: "none",
 };

--- a/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/app/[locale]/(auth)/forgot-password/page.tsx
@@ -8,18 +8,18 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { Box, VStack, Text } from "@chakra-ui/react";
+import { Box, VStack } from "@chakra-ui/react";
 import { Button, Input } from "@/components/ui";
 import { s } from "./styles";
 
 export default function ForgotPasswordPage(): React.JSX.Element {
   const t = useTranslations("auth.forgotPassword");
-  const { mutate: forgotPassword, isPending, isSuccess } = useForgotPassword({});
+  const { mutate: forgotPassword, isPending, isSuccess } = useForgotPassword();
 
   const schema = useMemo(
     () =>
       z.object({
-        email: z.email(t("emailRequired")),
+        email: z.string().trim().min(1, t("emailRequired")).email(t("emailInvalid")),
       }),
     [t]
   );
@@ -47,9 +47,7 @@ export default function ForgotPasswordPage(): React.JSX.Element {
         footerLinkLabel={t("backToLogin")}
         footerLinkHref={ROUTES.LOGIN}
       >
-        <Box textAlign="center" py={4}>
-          <Text color="mutedFg">{t("successDesc")}</Text>
-        </Box>
+        <Box textAlign="center" py={4} />
       </AuthCard>
     );
   }

--- a/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/app/[locale]/(auth)/forgot-password/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useMemo } from "react";
+import { AuthCard } from "@/components/AuthCard";
+import { ROUTES } from "@/lib/routes";
+import { useForgotPassword } from "@/lib/hooks/useForgotPassword";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Box, VStack, Text } from "@chakra-ui/react";
+import { Button, Input } from "@/components/ui";
+import { s } from "./styles";
+
+export default function ForgotPasswordPage(): React.JSX.Element {
+  const t = useTranslations("auth.forgotPassword");
+  const { mutate: forgotPassword, isPending, isSuccess } = useForgotPassword({});
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        email: z.email(t("emailRequired")),
+      }),
+    [t]
+  );
+
+  type FormData = z.infer<typeof schema>;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = (data: FormData): void => {
+    forgotPassword(data.email);
+  };
+
+  if (isSuccess) {
+    return (
+      <AuthCard
+        title={t("successTitle")}
+        subtitle={t("successDesc")}
+        footerText=""
+        footerLinkLabel={t("backToLogin")}
+        footerLinkHref={ROUTES.LOGIN}
+      >
+        <Box textAlign="center" py={4}>
+          <Text color="mutedFg">{t("successDesc")}</Text>
+        </Box>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title={t("title")}
+      subtitle={t("subtitle")}
+      footerText=""
+      footerLinkLabel={t("backToLogin")}
+      footerLinkHref={ROUTES.LOGIN}
+    >
+      <Box as="form" onSubmit={handleSubmit(onSubmit)}>
+        <VStack {...s.formStack}>
+          <Input
+            label={t("emailLabel")}
+            type="email"
+            autoComplete="email"
+            placeholder={t("emailPlaceholder")}
+            error={errors.email?.message}
+            {...register("email")}
+          />
+
+          <Button type="submit" loading={isPending} {...s.submitBtn}>
+            {t("submit")}
+          </Button>
+        </VStack>
+      </Box>
+    </AuthCard>
+  );
+}

--- a/app/[locale]/(auth)/forgot-password/styles.ts
+++ b/app/[locale]/(auth)/forgot-password/styles.ts
@@ -1,0 +1,1 @@
+export { sharedAuthStyles as s, brandLinkStyle, footerLinkStyle } from "../auth.styles";

--- a/app/[locale]/(auth)/login/login.styles.ts
+++ b/app/[locale]/(auth)/login/login.styles.ts
@@ -1,1 +1,6 @@
-export { sharedAuthStyles as s, brandLinkStyle, footerLinkStyle } from "../auth.styles";
+export {
+  sharedAuthStyles as s,
+  brandLinkStyle,
+  footerLinkStyle,
+  forgotPasswordLinkStyle,
+} from "../auth.styles";

--- a/app/[locale]/(auth)/login/page.tsx
+++ b/app/[locale]/(auth)/login/page.tsx
@@ -3,7 +3,7 @@
 import { Button, Input, PasswordInput } from "../../../../components/ui";
 import { AuthCard } from "@/components/AuthCard";
 import { useLogin } from "@/lib/hooks/useAuth";
-import { useRouter } from "@/lib/navigation";
+import { useRouter, Link } from "@/lib/navigation";
 import { ROUTES } from "@/lib/routes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Box, VStack } from "@chakra-ui/react";
@@ -11,7 +11,7 @@ import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { s } from "./login.styles";
+import { s, forgotPasswordLinkStyle } from "./login.styles";
 import { MIN_PASSWORD_LENGTH } from "@/lib/constants";
 
 export default function LoginPage() {
@@ -70,6 +70,12 @@ export default function LoginPage() {
             error={errors.password?.message}
             {...register("password")}
           />
+
+          <Box {...s.forgotPasswordWrapper}>
+            <Link href={ROUTES.FORGOT_PASSWORD} style={forgotPasswordLinkStyle}>
+              {t("forgotPassword")}
+            </Link>
+          </Box>
 
           <Button type="submit" loading={isPending} {...s.submitBtn}>
             {t("submit")}

--- a/app/[locale]/(auth)/register/page.tsx
+++ b/app/[locale]/(auth)/register/page.tsx
@@ -22,17 +22,23 @@ export default function RegisterPage(): React.JSX.Element {
   const locale = useLocale();
   const router = useRouter();
   const { mutate: registerMutation, isPending } = useRegister({
-    onSuccess: () => router.push(ROUTES.APP_DAILY_LAB),
+    onSuccess: () => router.push(ROUTES.LOGIN),
   });
 
   const registerSchema = useMemo(
     () =>
-      z.object({
-        name: z.string().min(MIN_NAME_LENGTH, t("nameMinLength")),
-        email: z.email(t("emailInvalid")),
-        password: z.string().min(MIN_PASSWORD_LENGTH, t("passwordMinLength")),
-        uiLanguage: z.enum(LANGUAGE_VALUES),
-      }),
+      z
+        .object({
+          name: z.string().min(MIN_NAME_LENGTH, t("nameMinLength")),
+          email: z.email(t("emailInvalid")),
+          password: z.string().min(MIN_PASSWORD_LENGTH, t("passwordMinLength")),
+          confirmPassword: z.string().min(MIN_PASSWORD_LENGTH, t("passwordMinLength")),
+          uiLanguage: z.enum(LANGUAGE_VALUES),
+        })
+        .refine((data) => data.password === data.confirmPassword, {
+          message: t("confirmPasswordMismatch"),
+          path: ["confirmPassword"],
+        }),
     [t]
   );
 
@@ -55,6 +61,7 @@ export default function RegisterPage(): React.JSX.Element {
 
   const selectedLang = watch("uiLanguage");
   const passwordValue = watch("password") ?? "";
+  const confirmPasswordValue = watch("confirmPassword") ?? "";
 
   const onSubmit = (data: RegisterForm): void => {
     registerMutation({
@@ -100,6 +107,15 @@ export default function RegisterPage(): React.JSX.Element {
             error={errors.password?.message}
             passwordValue={passwordValue}
             {...register("password")}
+          />
+
+          <PasswordInput
+            label={t("confirmPasswordLabel")}
+            autoComplete="new-password"
+            placeholder={t("confirmPasswordPlaceholder")}
+            error={errors.confirmPassword?.message}
+            passwordValue={confirmPasswordValue}
+            {...register("confirmPassword")}
           />
 
           <LanguageSelector

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -218,6 +218,7 @@
       "emailLabel": "EMAIL",
       "emailPlaceholder": "your@email.com",
       "emailRequired": "Email is required",
+      "emailInvalid": "Invalid email",
       "submit": "Send Reset Link →",
       "successTitle": "Check your email",
       "successDesc": "If an account with that email exists, we've sent a password reset link.",

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -218,6 +218,7 @@
       "emailLabel": "CORREO",
       "emailPlaceholder": "tu@correo.com",
       "emailRequired": "El correo es obligatorio",
+      "emailInvalid": "Correo inválido",
       "submit": "Enviar Enlace →",
       "successTitle": "Revisa tu correo",
       "successDesc": "Si existe una cuenta con ese correo, hemos enviado un enlace para restablecer la contraseña.",

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -218,6 +218,7 @@
       "emailLabel": "E-MAIL",
       "emailPlaceholder": "seu@email.com",
       "emailRequired": "E-mail é obrigatório",
+      "emailInvalid": "E-mail inválido",
       "submit": "Enviar Link de Redefinição →",
       "successTitle": "Verifique seu e-mail",
       "successDesc": "Se existir uma conta com este e-mail, enviamos um link para redefinir sua senha.",

--- a/lib/hooks/useForgotPassword.ts
+++ b/lib/hooks/useForgotPassword.ts
@@ -1,0 +1,32 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { authService } from "@/lib/auth.service";
+import { toaster } from "@/components/ui/toaster";
+
+export interface ForgotPasswordOptions {
+  onSuccess?: () => void;
+  onError?: (_error: Error) => void;
+}
+
+export function useForgotPassword(
+  options?: ForgotPasswordOptions
+): UseMutationResult<{ message: string }, Error, string> {
+  const t = useTranslations("auth.forgotPassword");
+
+  return useMutation({
+    mutationFn: (email: string): Promise<{ message: string }> => authService.forgotPassword(email),
+    onSuccess: (): void => {
+      options?.onSuccess?.();
+    },
+    onError: (error: Error): void => {
+      if (!options?.onError) {
+        toaster.create({
+          title: t("errorTitle"),
+          type: "error",
+          meta: { closable: true },
+        });
+      }
+      options?.onError?.(error);
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- **Register**: add `confirmPassword` field with Zod refine validation; redirect to `/login` on success instead of the app (registration now requires email verification before login)
- **Login**: add "Esqueceu sua senha?" link pointing to `/forgot-password`; `EMAIL_NOT_VERIFIED` error toast is handled in `useLogin` (via PR #107)

## Changes

| Commit | Files |
|--------|-------|
| `feat(register): add confirmPassword field; redirect to login on success` | `app/[locale]/(auth)/register/page.tsx` |
| `feat(login): add forgot-password link; handle EMAIL_NOT_VERIFIED toast` | `app/[locale]/(auth)/login/page.tsx`, `auth.styles.ts`, `login.styles.ts` |

> i18n keys (`forgotPassword`, `confirmPassword*`, `emailNotVerifiedTitle/Desc`) were already included in PR #107.

## Depends on

- PR #107 (`feat/auth-core-refactor`) — merged ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Página de "Esqueceu a Senha?" com fluxo de recuperação, feedback de envio e link de retorno ao login
  * Ganho de estado e carregamento no envio da recuperação de senha

* **Melhorias de UI**
  * Link "Esqueceu a Senha?" adicionado/estilizado na tela de login
  * Campo "Confirmar senha" no registro com validação cruzada

* **Alterações**
  * Após registro, usuários são redirecionados para a página de login
<!-- end of auto-generated comment: release notes by coderabbit.ai -->