### PR TITLE
feat(verify-email): add verify-email page

### DIFF
--- a/app/[locale]/(auth)/verify-email/page.tsx
+++ b/app/[locale]/(auth)/verify-email/page.tsx
@@ -48,7 +48,7 @@ function VerifyEmailContent(): React.JSX.Element {
 
   return (
     <AuthCard
-      title={isPending ? t("verifyingTitle") : isSuccess ? t("successTitle") : t("verifyingTitle")}
+      title={isSuccess ? t("successTitle") : t("verifyingTitle")}
       subtitle=""
       footerText=""
       footerLinkLabel={t("backToLogin")}

--- a/app/[locale]/(auth)/verify-email/page.tsx
+++ b/app/[locale]/(auth)/verify-email/page.tsx
@@ -61,8 +61,23 @@ function VerifyEmailContent(): React.JSX.Element {
 }
 
 export default function VerifyEmailPage(): React.JSX.Element {
+  const t = useTranslations("auth.verifyEmail");
+
   return (
-    <Suspense fallback={<Box minH="100vh" bg="canvas" role="status" aria-live="polite" />}>
+    <Suspense
+      fallback={
+        <Box
+          minH="100vh"
+          bg="canvas"
+          role="status"
+          aria-live="polite"
+          display="grid"
+          placeItems="center"
+        >
+          <Text color="mutedFg">{t("verifyingDesc")}</Text>
+        </Box>
+      }
+    >
       <VerifyEmailContent />
     </Suspense>
   );

--- a/app/[locale]/(auth)/verify-email/page.tsx
+++ b/app/[locale]/(auth)/verify-email/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, Suspense } from "react";
+import { AuthCard } from "@/components/AuthCard";
+import { useRouter } from "@/lib/navigation";
+import { useSearchParams } from "next/navigation";
+import { ROUTES } from "@/lib/routes";
+import { useVerifyEmail } from "@/lib/hooks/useVerifyEmail";
+import { useTranslations } from "next-intl";
+import { Box, Text } from "@chakra-ui/react";
+
+function VerifyEmailContent(): React.JSX.Element {
+  const t = useTranslations("auth.verifyEmail");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const {
+    mutate: verifyEmail,
+    isPending,
+    isError,
+    isSuccess,
+  } = useVerifyEmail({
+    onSuccess: () => router.push(ROUTES.APP_DAILY_LAB),
+  });
+
+  useEffect(() => {
+    if (token) {
+      verifyEmail(token);
+    }
+  }, [token, verifyEmail]);
+
+  if (!token || isError) {
+    return (
+      <AuthCard
+        title={t("errorTitle")}
+        subtitle=""
+        footerText=""
+        footerLinkLabel={t("backToRegister")}
+        footerLinkHref={ROUTES.REGISTER}
+      >
+        <Box textAlign="center" py={4}>
+          <Text color="error">{t("errorDesc")}</Text>
+        </Box>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title={isPending ? t("verifyingTitle") : isSuccess ? t("successTitle") : t("verifyingTitle")}
+      subtitle=""
+      footerText=""
+      footerLinkLabel={t("backToLogin")}
+      footerLinkHref={ROUTES.LOGIN}
+    >
+      <Box textAlign="center" py={4}>
+        <Text color="mutedFg">{isPending ? t("verifyingDesc") : t("successDesc")}</Text>
+      </Box>
+    </AuthCard>
+  );
+}
+
+export default function VerifyEmailPage(): React.JSX.Element {
+  return (
+    <Suspense fallback={<Box minH="100vh" bg="canvas" />}>
+      <VerifyEmailContent />
+    </Suspense>
+  );
+}

--- a/app/[locale]/(auth)/verify-email/page.tsx
+++ b/app/[locale]/(auth)/verify-email/page.tsx
@@ -17,7 +17,6 @@ function VerifyEmailContent(): React.JSX.Element {
 
   const {
     mutate: verifyEmail,
-    isPending,
     isError,
     isSuccess,
   } = useVerifyEmail({
@@ -55,7 +54,7 @@ function VerifyEmailContent(): React.JSX.Element {
       footerLinkHref={ROUTES.LOGIN}
     >
       <Box textAlign="center" py={4}>
-        <Text color="mutedFg">{isPending ? t("verifyingDesc") : t("successDesc")}</Text>
+        <Text color="mutedFg">{isSuccess ? t("successDesc") : t("verifyingDesc")}</Text>
       </Box>
     </AuthCard>
   );
@@ -63,7 +62,7 @@ function VerifyEmailContent(): React.JSX.Element {
 
 export default function VerifyEmailPage(): React.JSX.Element {
   return (
-    <Suspense fallback={<Box minH="100vh" bg="canvas" />}>
+    <Suspense fallback={<Box minH="100vh" bg="canvas" role="status" aria-live="polite" />}>
       <VerifyEmailContent />
     </Suspense>
   );

--- a/app/[locale]/(auth)/verify-email/styles.ts
+++ b/app/[locale]/(auth)/verify-email/styles.ts
@@ -1,0 +1,1 @@
+export { sharedAuthStyles as s } from "../auth.styles";

--- a/app/[locale]/(auth)/verify-email/styles.ts
+++ b/app/[locale]/(auth)/verify-email/styles.ts
@@ -1,1 +1,0 @@
-export { sharedAuthStyles as s } from "../auth.styles";

--- a/lib/hooks/useVerifyEmail.ts
+++ b/lib/hooks/useVerifyEmail.ts
@@ -2,6 +2,7 @@ import { useMutation, type UseMutationResult } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { authService } from "@/lib/auth.service";
 import { api } from "@/lib/api-client";
+import { useAuthContext } from "@/lib/auth-context";
 import { toaster } from "@/components/ui/toaster";
 import type { AuthResponse } from "@/types/auth";
 
@@ -14,11 +15,14 @@ export function useVerifyEmail(
   options?: VerifyEmailOptions
 ): UseMutationResult<AuthResponse, Error, string> {
   const t = useTranslations("auth.verifyEmail");
+  const { setAccessToken, setUser } = useAuthContext();
 
   return useMutation({
     mutationFn: (token: string): Promise<AuthResponse> => authService.verifyEmail(token),
     onSuccess: (data: AuthResponse): void => {
       api.setToken(data.token);
+      setAccessToken(data.token);
+      setUser(data.user);
       toaster.create({
         title: t("toastSuccessTitle"),
         description: t("toastSuccessDesc"),

--- a/lib/hooks/useVerifyEmail.ts
+++ b/lib/hooks/useVerifyEmail.ts
@@ -1,0 +1,40 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { authService } from "@/lib/auth.service";
+import { api } from "@/lib/api-client";
+import { toaster } from "@/components/ui/toaster";
+import type { AuthResponse } from "@/types/auth";
+
+export interface VerifyEmailOptions {
+  onSuccess?: (_data: AuthResponse) => void;
+  onError?: (_error: Error) => void;
+}
+
+export function useVerifyEmail(
+  options?: VerifyEmailOptions
+): UseMutationResult<AuthResponse, Error, string> {
+  const t = useTranslations("auth.verifyEmail");
+
+  return useMutation({
+    mutationFn: (token: string): Promise<AuthResponse> => authService.verifyEmail(token),
+    onSuccess: (data: AuthResponse): void => {
+      api.setToken(data.token);
+      toaster.create({
+        title: t("toastSuccessTitle"),
+        description: t("toastSuccessDesc"),
+        type: "success",
+        meta: { closable: true },
+      });
+      options?.onSuccess?.(data);
+    },
+    onError: (error: Error): void => {
+      toaster.create({
+        title: t("toastErrorTitle"),
+        description: t("toastErrorDesc"),
+        type: "error",
+        meta: { closable: true },
+      });
+      options?.onError?.(error);
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `VerifyEmailPage` with `Suspense` wrapper for `useSearchParams` compatibility
- Reads `token` from search params and auto-triggers `verifyEmail` mutation on mount
- Shows error state (invalid/missing token) with link back to register
- Shows loading/success state with link back to login

## Test plan
- [ ] Navigate to `/verify-email?token=valid-token` — should auto-verify and redirect to app
- [ ] Navigate to `/verify-email?token=invalid-token` — should show error state
- [ ] Navigate to `/verify-email` (no token) — should show error state immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Página de verificação de e-mail com feedback visual do progresso.
  * Mensagens localizadas durante o processo e após conclusão.
  * Notificações (sucesso/erro) claras para o usuário.
  * Redirecionamento automático para o aplicativo após verificação bem-sucedida.
  * Opção e link para retornar ao registro em caso de falha.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->