### PR TITLE
feat(reset-password): add reset-password page

### DIFF
--- a/app/[locale]/(auth)/reset-password/page.tsx
+++ b/app/[locale]/(auth)/reset-password/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useMemo, useState, useEffect, Suspense } from "react";
+import { AuthCard } from "@/components/AuthCard";
+import { useRouter } from "@/lib/navigation";
+import { useSearchParams } from "next/navigation";
+import { ROUTES } from "@/lib/routes";
+import { useResetPassword } from "@/lib/hooks/useResetPassword";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Box, VStack, Text } from "@chakra-ui/react";
+import { Button, PasswordInput } from "@/components/ui";
+import { s } from "./styles";
+import { MIN_PASSWORD_LENGTH } from "@/lib/constants";
+
+function ResetPasswordForm(): React.JSX.Element {
+  const t = useTranslations("auth.resetPassword");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [tokenError, setTokenError] = useState(false);
+
+  const token = searchParams.get("token");
+
+  useEffect(() => {
+    if (!token) {
+      setTokenError(true);
+    }
+  }, [token]);
+
+  const { mutate: resetPassword, isPending } = useResetPassword({
+    onSuccess: () => router.push(ROUTES.LOGIN),
+  });
+
+  const schema = useMemo(
+    () =>
+      z
+        .object({
+          password: z.string().min(MIN_PASSWORD_LENGTH, t("passwordMinLength")),
+          confirmPassword: z.string().min(MIN_PASSWORD_LENGTH, t("passwordMinLength")),
+        })
+        .refine((data) => data.password === data.confirmPassword, {
+          message: t("confirmPasswordMismatch"),
+          path: ["confirmPassword"],
+        }),
+    [t]
+  );
+
+  type FormData = z.infer<typeof schema>;
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const passwordValue = watch("password") ?? "";
+  const confirmPasswordValue = watch("confirmPassword") ?? "";
+
+  const onSubmit = (data: FormData): void => {
+    if (!token) return;
+    resetPassword({ token, newPassword: data.password });
+  };
+
+  if (tokenError) {
+    return (
+      <AuthCard
+        title={t("title")}
+        subtitle=""
+        footerText=""
+        footerLinkLabel={t("backToForgotPassword")}
+        footerLinkHref={ROUTES.FORGOT_PASSWORD}
+      >
+        <Box textAlign="center" py={4}>
+          <Text color="error" mb={4}>
+            {t("tokenInvalid")}
+          </Text>
+        </Box>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title={t("title")}
+      subtitle={t("subtitle")}
+      footerText=""
+      footerLinkLabel={t("backToForgotPassword")}
+      footerLinkHref={ROUTES.FORGOT_PASSWORD}
+    >
+      <Box as="form" onSubmit={handleSubmit(onSubmit)}>
+        <VStack {...s.formStack}>
+          <PasswordInput
+            label={t("passwordLabel")}
+            autoComplete="new-password"
+            placeholder={t("passwordPlaceholder")}
+            error={errors.password?.message}
+            passwordValue={passwordValue}
+            {...register("password")}
+          />
+
+          <PasswordInput
+            label={t("confirmPasswordLabel")}
+            autoComplete="new-password"
+            placeholder={t("confirmPasswordPlaceholder")}
+            error={errors.confirmPassword?.message}
+            passwordValue={confirmPasswordValue}
+            {...register("confirmPassword")}
+          />
+
+          <Button type="submit" loading={isPending} {...s.submitBtn}>
+            {t("submit")}
+          </Button>
+        </VStack>
+      </Box>
+    </AuthCard>
+  );
+}
+
+export default function ResetPasswordPage(): React.JSX.Element {
+  const t = useTranslations("auth.resetPassword");
+
+  return (
+    <Suspense
+      fallback={
+        <Box
+          minH="100vh"
+          bg="canvas"
+          role="status"
+          aria-live="polite"
+          display="grid"
+          placeItems="center"
+        >
+          <Text color="mutedFg">{t("loading")}</Text>
+        </Box>
+      }
+    >
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}

--- a/app/[locale]/(auth)/reset-password/styles.ts
+++ b/app/[locale]/(auth)/reset-password/styles.ts
@@ -1,0 +1,1 @@
+export { sharedAuthStyles as s, brandLinkStyle, footerLinkStyle } from "../auth.styles";

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -241,7 +241,8 @@
       "toastSuccessDesc": "You can now log in with your new password.",
       "toastErrorTitle": "Reset failed",
       "tokenInvalid": "This link has expired or is invalid. Please request a new one.",
-      "backToForgotPassword": "← Request new link"
+      "backToForgotPassword": "← Request new link",
+      "loading": "Loading..."
     },
     "verifyEmail": {
       "verifyingTitle": "Verifying...",

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -241,7 +241,8 @@
       "toastSuccessDesc": "Ahora puedes iniciar sesión con tu nueva contraseña.",
       "toastErrorTitle": "Error al restablecer",
       "tokenInvalid": "Este enlace ha expirado o es inválido. Por favor, solicita uno nuevo.",
-      "backToForgotPassword": "← Solicitar nuevo enlace"
+      "backToForgotPassword": "← Solicitar nuevo enlace",
+      "loading": "Cargando..."
     },
     "verifyEmail": {
       "verifyingTitle": "Verificando...",

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -241,7 +241,8 @@
       "toastSuccessDesc": "Agora você pode fazer login com sua nova senha.",
       "toastErrorTitle": "Falha ao redefinir",
       "tokenInvalid": "Este link expirou ou é inválido. Por favor, solicite um novo.",
-      "backToForgotPassword": "← Solicitar novo link"
+      "backToForgotPassword": "← Solicitar novo link",
+      "loading": "Carregando..."
     },
     "verifyEmail": {
       "verifyingTitle": "Verificando...",

--- a/lib/hooks/useResetPassword.ts
+++ b/lib/hooks/useResetPassword.ts
@@ -1,0 +1,47 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { authService } from "@/lib/auth.service";
+import { toaster } from "@/components/ui/toaster";
+import { useTranslatedError } from "./useTranslatedError";
+
+export interface ResetPasswordOptions {
+  onSuccess?: () => void;
+  onError?: (_error: Error) => void;
+}
+
+export function useResetPassword(
+  options?: ResetPasswordOptions
+): UseMutationResult<{ message: string }, Error, { token: string; newPassword: string }> {
+  const t = useTranslations("auth.resetPassword");
+  const { translateError } = useTranslatedError();
+
+  return useMutation({
+    mutationFn: ({
+      token,
+      newPassword,
+    }: {
+      token: string;
+      newPassword: string;
+    }): Promise<{ message: string }> => authService.resetPassword(token, newPassword),
+    onSuccess: (): void => {
+      toaster.create({
+        title: t("toastSuccessTitle"),
+        description: t("toastSuccessDesc"),
+        type: "success",
+        meta: { closable: true },
+      });
+      options?.onSuccess?.();
+    },
+    onError: (error: Error): void => {
+      if (!options?.onError) {
+        toaster.create({
+          title: t("toastErrorTitle"),
+          description: translateError(error),
+          type: "error",
+          meta: { closable: true },
+        });
+      }
+      options?.onError?.(error);
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `useResetPassword` hook using `useMutation` + `authService.resetPassword`, with translated toasts and `useTranslatedError` for error messages
- Adds `ResetPasswordPage` with `Suspense` wrapper (a11y: `role="status"` + `aria-live="polite"`) reading token from search params
- Shows error state when token is missing with link back to forgot-password
- Redirects to login on success
- Adds `loading` i18n key to `auth.resetPassword` namespace (en-US, pt-BR, es-ES)

## Test plan
- [ ] Navigate to `/reset-password?token=valid-token` — form visible, submit resets password and redirects to login
- [ ] Navigate to `/reset-password` (no token) — shows invalid token error with link to forgot-password
- [ ] Password mismatch — validation error shown inline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Adicionada página de redefinição de senha com formulário validado e estados de carregamento
  * Suporte para redefinição de senha em múltiplos idiomas (inglês, espanhol e português-brasileiro)
  * Integração com tratamento de erros e confirmação visual para usuários

<!-- end of auto-generated comment: release notes by coderabbit.ai -->