### PR TITLE
feat: forgot password and reset password pages

### DIFF
--- a/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/app/[locale]/(auth)/forgot-password/page.tsx
@@ -66,6 +66,7 @@ export default function ForgotPasswordPage(): React.JSX.Element {
             label={t("emailLabel")}
             type="email"
             autoComplete="email"
+            spellCheck={false}
             placeholder={t("emailPlaceholder")}
             error={errors.email?.message}
             {...register("email")}

--- a/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/app/[locale]/(auth)/forgot-password/page.tsx
@@ -47,7 +47,7 @@ export default function ForgotPasswordPage(): React.JSX.Element {
         footerLinkLabel={t("backToLogin")}
         footerLinkHref={ROUTES.LOGIN}
       >
-        <Box textAlign="center" py={4} />
+        <Box {...s.successSpacer} />
       </AuthCard>
     );
   }

--- a/app/[locale]/(auth)/forgot-password/styles.ts
+++ b/app/[locale]/(auth)/forgot-password/styles.ts
@@ -1,1 +1,9 @@
-export { sharedAuthStyles as s } from "../auth.styles";
+import type { SystemStyleObject } from "@chakra-ui/react";
+import { sharedAuthStyles } from "../auth.styles";
+
+export const s = {
+  ...sharedAuthStyles,
+  successSpacer: {
+    py: 4,
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/app/[locale]/(auth)/reset-password/page.tsx
+++ b/app/[locale]/(auth)/reset-password/page.tsx
@@ -19,7 +19,7 @@ function ResetPasswordForm(): React.JSX.Element {
   const t = useTranslations("auth.resetPassword");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const token = searchParams.get("token");
+  const token = searchParams.get("token")?.trim();
   const tokenError = !token;
 
   const { mutate: resetPassword, isPending } = useResetPassword({

--- a/app/[locale]/(auth)/reset-password/page.tsx
+++ b/app/[locale]/(auth)/reset-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useEffect, Suspense } from "react";
+import { useMemo, Suspense } from "react";
 import { AuthCard } from "@/components/AuthCard";
 import { useRouter } from "@/lib/navigation";
 import { useSearchParams } from "next/navigation";
@@ -10,7 +10,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { Box, VStack, Text } from "@chakra-ui/react";
+import { Box, Text, VStack } from "@chakra-ui/react";
 import { Button, PasswordInput } from "@/components/ui";
 import { s } from "./styles";
 import { MIN_PASSWORD_LENGTH } from "@/lib/constants";
@@ -19,15 +19,8 @@ function ResetPasswordForm(): React.JSX.Element {
   const t = useTranslations("auth.resetPassword");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [tokenError, setTokenError] = useState(false);
-
   const token = searchParams.get("token");
-
-  useEffect(() => {
-    if (!token) {
-      setTokenError(true);
-    }
-  }, [token]);
+  const tokenError = !token;
 
   const { mutate: resetPassword, isPending } = useResetPassword({
     onSuccess: () => router.push(ROUTES.LOGIN),
@@ -59,7 +52,6 @@ function ResetPasswordForm(): React.JSX.Element {
   });
 
   const passwordValue = watch("password") ?? "";
-  const confirmPasswordValue = watch("confirmPassword") ?? "";
 
   const onSubmit = (data: FormData): void => {
     if (!token) return;
@@ -108,7 +100,6 @@ function ResetPasswordForm(): React.JSX.Element {
             autoComplete="new-password"
             placeholder={t("confirmPasswordPlaceholder")}
             error={errors.confirmPassword?.message}
-            passwordValue={confirmPasswordValue}
             {...register("confirmPassword")}
           />
 

--- a/app/[locale]/(auth)/reset-password/page.tsx
+++ b/app/[locale]/(auth)/reset-password/page.tsx
@@ -67,10 +67,8 @@ function ResetPasswordForm(): React.JSX.Element {
         footerLinkLabel={t("backToForgotPassword")}
         footerLinkHref={ROUTES.FORGOT_PASSWORD}
       >
-        <Box textAlign="center" py={4}>
-          <Text color="error" mb={4}>
-            {t("tokenInvalid")}
-          </Text>
+        <Box {...s.tokenErrorBox}>
+          <Text {...s.tokenErrorText}>{t("tokenInvalid")}</Text>
         </Box>
       </AuthCard>
     );
@@ -118,14 +116,7 @@ export default function ResetPasswordPage(): React.JSX.Element {
   return (
     <Suspense
       fallback={
-        <Box
-          minH="100vh"
-          bg="canvas"
-          role="status"
-          aria-live="polite"
-          display="grid"
-          placeItems="center"
-        >
+        <Box role="status" aria-live="polite" {...s.suspenseFallback}>
           <Text color="mutedFg">{t("loading")}</Text>
         </Box>
       }

--- a/app/[locale]/(auth)/reset-password/styles.ts
+++ b/app/[locale]/(auth)/reset-password/styles.ts
@@ -1,1 +1,20 @@
-export { sharedAuthStyles as s } from "../auth.styles";
+import type { SystemStyleObject } from "@chakra-ui/react";
+import { sharedAuthStyles } from "../auth.styles";
+
+export const s = {
+  ...sharedAuthStyles,
+  suspenseFallback: {
+    minH: "100vh",
+    bg: "canvas",
+    display: "grid",
+    placeItems: "center",
+  },
+  tokenErrorBox: {
+    textAlign: "center",
+    py: 4,
+  },
+  tokenErrorText: {
+    color: "error",
+    mb: 4,
+  },
+} satisfies Record<string, SystemStyleObject>;


### PR DESCRIPTION
## Summary
- Forgot password page: form with email input, calls `/api/auth/forgot-password`
- Reset password page: form with new password + confirm, calls `/api/auth/reset-password` with token from query string
- Both pages use `AuthCard` layout and follow existing auth page patterns

## Dependencies
- Requires imm-api PR #131 (merged) — `POST /api/auth/forgot-password` and `POST /api/auth/reset-password` endpoints

## Test plan
- [ ] All 198 unit/integration tests passing
- [ ] E2E: `landing.spec.ts` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  - Simplificações internas na validação de token da página de redefinição de senha.
  - Abstração e centralização de estilos compartilhados nas páginas de autenticação para melhor manutenção e consistência visual.

* **Style**
  - Aplicação consistente de estilos padronizados nas páginas de recuperação e redefinição de senha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->