### PR TITLE
W4: fix analytics page — styles, grid anchoring and a11y

### DIFF
--- a/components/Analytics/HabitStatsGrid/styles.ts
+++ b/components/Analytics/HabitStatsGrid/styles.ts
@@ -17,16 +17,17 @@ export const s = {
     display: "flex",
     flexDirection: "column",
     cursor: "pointer",
-    transition: "transform 0.1s, box-shadow 0.1s, border-bottom 0.1s",
+    _motionSafe: {
+      transition: "transform 0.1s, box-shadow 0.1s, border-bottom 0.1s",
+    },
   },
   cardSelected: {
     borderBottom: "0.375rem solid black",
     boxShadow: "0 0.5rem 0 0 black",
-    transform: "translateY(-0.1875rem)",
+    _motionSafe: { transform: "translateY(-0.1875rem)" },
   },
   cardUnselected: {
     borderBottom: "0.1875rem solid black",
-    transform: "none",
   },
   toneMint: { bg: "surface.mint" },
   toneSky: { bg: "surface.sky" },

--- a/components/Analytics/StreakCalendar/index.tsx
+++ b/components/Analytics/StreakCalendar/index.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Text, VStack, HStack } from "@chakra-ui/react";
 import { useTranslations, useLocale } from "next-intl";
-import { format, subDays } from "date-fns";
+import { format, parseISO, subDays } from "date-fns";
 import { formatEntryDate } from "@/lib/date-locale";
 import { toChakraColor } from "@/lib/habit-utils";
 import type { HabitLog, HabitStat } from "../types";
@@ -21,10 +21,18 @@ function buildGrid(
 ): { date: string; completed: boolean }[] {
   const safeCurrentDay = Math.max(1, Math.min(currentDay, DAYS));
   const completedSet = new Set((logs ?? []).filter((l) => l.completed).map((l) => l.logDate));
-  const today = new Date();
-  const startDate = subDays(today, safeCurrentDay - 1);
-  const cells: { date: string; completed: boolean }[] = [];
 
+  // Anchor the grid to the earliest completed log date instead of computing
+  // from habit.startDate (UTC) + today. habit.startDate is stored in UTC but
+  // logs use the user's local date — if the user creates habits near midnight UTC,
+  // startDate ends up one day ahead of the actual first log, causing the grid to
+  // skip that log entirely.
+  const sortedDates = [...completedSet].sort();
+  const startDate = sortedDates[0]
+    ? parseISO(sortedDates[0])
+    : subDays(new Date(), safeCurrentDay - 1);
+
+  const cells: { date: string; completed: boolean }[] = [];
   for (let i = 0; i < DAYS; i++) {
     const date = format(subDays(startDate, -i), "yyyy-MM-dd");
     cells.push({ date, completed: completedSet.has(date) });

--- a/components/Analytics/StreakCalendar/index.tsx
+++ b/components/Analytics/StreakCalendar/index.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Text, VStack, HStack } from "@chakra-ui/react";
 import { useTranslations, useLocale } from "next-intl";
-import { format, parseISO, subDays } from "date-fns";
+import { addDays, format, isValid, parseISO, subDays } from "date-fns";
 import { formatEntryDate } from "@/lib/date-locale";
 import { toChakraColor } from "@/lib/habit-utils";
 import type { HabitLog, HabitStat } from "../types";
@@ -28,13 +28,12 @@ function buildGrid(
   // startDate ends up one day ahead of the actual first log, causing the grid to
   // skip that log entirely.
   const sortedDates = [...completedSet].sort();
-  const startDate = sortedDates[0]
-    ? parseISO(sortedDates[0])
-    : subDays(new Date(), safeCurrentDay - 1);
+  const parsed = sortedDates[0] ? parseISO(sortedDates[0]) : null;
+  const startDate = parsed && isValid(parsed) ? parsed : subDays(new Date(), safeCurrentDay - 1);
 
   const cells: { date: string; completed: boolean }[] = [];
   for (let i = 0; i < DAYS; i++) {
-    const date = format(subDays(startDate, -i), "yyyy-MM-dd");
+    const date = format(addDays(startDate, i), "yyyy-MM-dd");
     cells.push({ date, completed: completedSet.has(date) });
   }
 

--- a/components/Calendar/index.tsx
+++ b/components/Calendar/index.tsx
@@ -98,7 +98,12 @@ export function Calendar({ entries, currentMonth, onMonthChange, onDayClick }: C
               }
               onKeyDown={
                 hasEntries
-                  ? (e) => (e.key === "Enter" || e.key === " ") && onDayClick(dateStr, dayEntries)
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onDayClick(dateStr, dayEntries);
+                      }
+                    }
                   : undefined
               }
             >

--- a/components/Calendar/index.tsx
+++ b/components/Calendar/index.tsx
@@ -93,6 +93,9 @@ export function Calendar({ entries, currentMonth, onMonthChange, onDayClick }: C
               onClick={hasEntries ? () => onDayClick(dateStr, dayEntries) : undefined}
               role={hasEntries ? "button" : undefined}
               tabIndex={hasEntries ? 0 : undefined}
+              aria-label={
+                hasEntries ? t("dayAriaLabel", { day, count: dayEntries.length }) : undefined
+              }
               onKeyDown={
                 hasEntries
                   ? (e) => (e.key === "Enter" || e.key === " ") && onDayClick(dateStr, dayEntries)

--- a/components/Calendar/styles.ts
+++ b/components/Calendar/styles.ts
@@ -32,9 +32,11 @@ export const s = {
     fontSize: "lg",
     cursor: "pointer",
     boxShadow: "brutal-sm",
-    transition: "transform 0.1s ease, box-shadow 0.1s ease",
-    _hover: { transform: "translate(-1px, -1px)", boxShadow: "brutal" },
-    _active: { transform: "translate(1px, 1px)", boxShadow: "none" },
+    _motionSafe: {
+      transition: "transform 0.1s ease, box-shadow 0.1s ease",
+      _hover: { transform: "translate(-1px, -1px)", boxShadow: "brutal" },
+      _active: { transform: "translate(1px, 1px)", boxShadow: "none" },
+    },
     _focusVisible: { outline: "3px solid", outlineColor: "ring", outlineOffset: "2px" },
   },
 
@@ -89,9 +91,11 @@ export const s = {
     bg: "surface.mint",
     opacity: 1,
     cursor: "pointer",
-    transition: "transform 0.1s ease, box-shadow 0.1s ease",
-    _hover: { transform: "translate(-1px, -1px)", boxShadow: "brutal-sm" },
-    _active: { transform: "translate(1px, 1px)", boxShadow: "none" },
+    _motionSafe: {
+      transition: "transform 0.1s ease, box-shadow 0.1s ease",
+      _hover: { transform: "translate(-1px, -1px)", boxShadow: "brutal-sm" },
+      _active: { transform: "translate(1px, 1px)", boxShadow: "none" },
+    },
     _focusVisible: { outline: "3px solid", outlineColor: "ring", outlineOffset: "2px" },
   },
 

--- a/components/ui/score-line-chart.tsx
+++ b/components/ui/score-line-chart.tsx
@@ -11,7 +11,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { addDays, format, subDays } from "date-fns";
+import { addDays, format, parseISO, subDays } from "date-fns";
 import { chartColors, legendWrapperStyle, s, tooltipContentStyle } from "./score-line-chart.styles";
 
 export interface ScoreEntry {
@@ -38,8 +38,12 @@ const CHART_MARGIN = { top: 30, right: 16, bottom: 40, left: 32 };
 
 export function ScoreLineChart({ entries, currentDay, labels }: ScoreLineChartProps) {
   const safeCurrentDay = Math.max(1, Math.min(currentDay, TOTAL_DAYS));
-  const today = new Date();
-  const startDate = subDays(today, safeCurrentDay - 1);
+
+  const sortedEntries = [...entries].sort((a, b) => a.date.localeCompare(b.date));
+  const startDate = sortedEntries[0]
+    ? parseISO(sortedEntries[0].date)
+    : subDays(new Date(), safeCurrentDay - 1);
+
   const entryMap = new Map(entries.map((entry) => [entry.date, entry]));
 
   const data = Array.from({ length: TOTAL_DAYS }, (_, i) => {

--- a/components/ui/score-line-chart.tsx
+++ b/components/ui/score-line-chart.tsx
@@ -39,9 +39,11 @@ const CHART_MARGIN = { top: 30, right: 16, bottom: 40, left: 32 };
 export function ScoreLineChart({ entries, currentDay, labels }: ScoreLineChartProps) {
   const safeCurrentDay = Math.max(1, Math.min(currentDay, TOTAL_DAYS));
 
-  const sortedEntries = [...entries].sort((a, b) => a.date.localeCompare(b.date));
-  const parsed = sortedEntries[0] ? parseISO(sortedEntries[0].date) : null;
-  const startDate = parsed && isValid(parsed) ? parsed : subDays(new Date(), safeCurrentDay - 1);
+  const startDate =
+    entries
+      .map((entry) => parseISO(entry.date))
+      .filter((date) => isValid(date))
+      .sort((a, b) => a.getTime() - b.getTime())[0] ?? subDays(new Date(), safeCurrentDay - 1);
 
   const entryMap = new Map(entries.map((entry) => [entry.date, entry]));
 

--- a/components/ui/score-line-chart.tsx
+++ b/components/ui/score-line-chart.tsx
@@ -11,7 +11,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { addDays, format, parseISO, subDays } from "date-fns";
+import { addDays, format, isValid, parseISO, subDays } from "date-fns";
 import { chartColors, legendWrapperStyle, s, tooltipContentStyle } from "./score-line-chart.styles";
 
 export interface ScoreEntry {
@@ -40,9 +40,8 @@ export function ScoreLineChart({ entries, currentDay, labels }: ScoreLineChartPr
   const safeCurrentDay = Math.max(1, Math.min(currentDay, TOTAL_DAYS));
 
   const sortedEntries = [...entries].sort((a, b) => a.date.localeCompare(b.date));
-  const startDate = sortedEntries[0]
-    ? parseISO(sortedEntries[0].date)
-    : subDays(new Date(), safeCurrentDay - 1);
+  const parsed = sortedEntries[0] ? parseISO(sortedEntries[0].date) : null;
+  const startDate = parsed && isValid(parsed) ? parsed : subDays(new Date(), safeCurrentDay - 1);
 
   const entryMap = new Map(entries.map((entry) => [entry.date, entry]));
 

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -632,7 +632,7 @@
     },
     "weekdays": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
     "selectedDate": "Selected Date",
-    "dayAriaLabel": "Day {day}, {count, plural, one {1 entry} other {# entries}}"
+    "dayAriaLabel": "Day {day}, {count, plural, one {# entry} other {# entries}}"
   },
   "analytics": {
     "pageTitle": "Analytics",

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -632,7 +632,7 @@
     },
     "weekdays": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
     "selectedDate": "Selected Date",
-    "dayAriaLabel": "Day {day}, {count} entries"
+    "dayAriaLabel": "Day {day}, {count, plural, one {1 entry} other {# entries}}"
   },
   "analytics": {
     "pageTitle": "Analytics",

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -632,7 +632,7 @@
     },
     "weekdays": ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
     "selectedDate": "Fecha Seleccionada",
-    "dayAriaLabel": "Día {day}, {count, plural, one {1 registro} other {# registros}}"
+    "dayAriaLabel": "Día {day}, {count, plural, one {# registro} other {# registros}}"
   },
   "analytics": {
     "pageTitle": "Análisis",

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -632,7 +632,7 @@
     },
     "weekdays": ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
     "selectedDate": "Fecha Seleccionada",
-    "dayAriaLabel": "Día {day}, {count} registros"
+    "dayAriaLabel": "Día {day}, {count, plural, one {1 registro} other {# registros}}"
   },
   "analytics": {
     "pageTitle": "Análisis",

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -632,7 +632,7 @@
     },
     "weekdays": ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
     "selectedDate": "Data Selecionada",
-    "dayAriaLabel": "Dia {day}, {count, plural, one {1 registro} other {# registros}}"
+    "dayAriaLabel": "Dia {day}, {count, plural, one {# registro} other {# registros}}"
   },
   "analytics": {
     "pageTitle": "Análises",

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -632,7 +632,7 @@
     },
     "weekdays": ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
     "selectedDate": "Data Selecionada",
-    "dayAriaLabel": "Dia {day}, {count} registros"
+    "dayAriaLabel": "Dia {day}, {count, plural, one {1 registro} other {# registros}}"
   },
   "analytics": {
     "pageTitle": "Análises",


### PR DESCRIPTION
## Summary

- Wrap transitions in `_motionSafe` on `HabitStatsGrid/styles.ts` and `Calendar/styles.ts` (respects prefers-reduced-motion)
- Anchor streak grid and score chart to the earliest completed log date instead of computing from today — fixes UTC midnight offset issue
- Add `aria-label` on calendar day cells with entry count for screen readers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Rótulos ARIA mais descritivos para dias do calendário com registros (melhora acessibilidade)

* **Melhorias**
  * Animações e transições agora respeitam preferências de movimento do usuário
  * Calendários e gráficos passam a ancorar o início na data real dos dados quando disponível
  * Pluralização aprimorada nas traduções do rótulo de dias (en-US, es-ES, pt-BR)
  * Melhor comportamento de teclado em dias com entradas (prevenção de ações indesejadas)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->