### PR TITLE
W5: fix settings page — LanguageSelector styles.ts, _motionSafe, DeleteAccountModal form pattern

### DIFF
--- a/app/[locale]/(app)/settings/page.tsx
+++ b/app/[locale]/(app)/settings/page.tsx
@@ -110,8 +110,15 @@ export default function SettingsPage(): React.JSX.Element {
 
       if (Object.keys(changed).length === 0) return;
 
-      await saveProfile(changed);
-      if (dirtyFields.ui_language) {
+      const needsLocaleChange = dirtyFields.ui_language;
+      const updatedProfile = await saveProfile(changed);
+      reset({
+        name: updatedProfile.name,
+        bio: updatedProfile.profile?.bio ?? "",
+        timezone: updatedProfile.profile?.timezone ?? "",
+        ui_language: updatedProfile.profile?.uiLanguage ?? "pt-BR",
+      });
+      if (needsLocaleChange) {
         router.replace(pathname, { locale: data.ui_language });
       }
     } catch {}
@@ -143,6 +150,7 @@ export default function SettingsPage(): React.JSX.Element {
             <Input
               label={t("nameLabel")}
               placeholder={t("namePlaceholder")}
+              autoComplete="name"
               error={errors.name?.message}
               {...register("name")}
             />

--- a/app/[locale]/(app)/settings/page.tsx
+++ b/app/[locale]/(app)/settings/page.tsx
@@ -15,6 +15,7 @@ import type { UILanguage } from "@/lib/constants";
 import { useGetProfile, useUpdateProfile } from "@/lib/hooks/useProfile";
 import { useRouter, usePathname } from "@/lib/navigation";
 import { toaster } from "@/components/ui/toaster";
+import { logger } from "@/lib/logger";
 import { PageWrapper } from "@/components/PageWrapper";
 import { s } from "./settings.styles";
 import { AI_DAILY_LIMIT as AI_LIMIT, MIN_NAME_LENGTH } from "@/lib/constants";
@@ -121,7 +122,15 @@ export default function SettingsPage(): React.JSX.Element {
       if (needsLocaleChange) {
         router.replace(pathname, { locale: data.ui_language });
       }
-    } catch {}
+    } catch (err) {
+      logger.error({ err }, "settings: failed to save profile");
+      toaster.create({
+        type: "error",
+        title: t("toastErrorTitle"),
+        description: t("toastErrorDesc"),
+        meta: { closable: true },
+      });
+    }
   };
 
   const usagePercent = profile

--- a/app/[locale]/(app)/settings/settings.styles.ts
+++ b/app/[locale]/(app)/settings/settings.styles.ts
@@ -29,6 +29,7 @@ export const s = {
     textTransform: "uppercase",
     letterSpacing: "0.06em",
     lineHeight: 1.1,
+    textWrap: "balance",
     pb: 3,
     borderBottom: "2px solid black",
   },
@@ -85,7 +86,7 @@ export const s = {
   usageFill: {
     h: "100%",
     bg: "secondary",
-    transition: "width 0.3s ease",
+    _motionSafe: { transition: "width 0.3s ease" },
   },
 
   saveBtn: {
@@ -109,6 +110,7 @@ export const s = {
     textTransform: "uppercase",
     letterSpacing: "0.06em",
     lineHeight: 1.1,
+    textWrap: "balance",
     color: "black",
   },
 
@@ -134,6 +136,7 @@ export const s = {
     textTransform: "uppercase",
     letterSpacing: "0.06em",
     lineHeight: 1.1,
+    textWrap: "balance",
   },
 
   privacyDescription: {
@@ -157,6 +160,7 @@ export const s = {
     textTransform: "uppercase",
     letterSpacing: "0.06em",
     lineHeight: 1.1,
+    textWrap: "balance",
   },
 
   accountDescription: {

--- a/components/LanguageSelector/index.tsx
+++ b/components/LanguageSelector/index.tsx
@@ -1,21 +1,14 @@
 "use client";
 
 import { Box, Text, chakra } from "@chakra-ui/react";
-import { useCallback, useId, useRef } from "react";
+import { useId, useRef } from "react";
 import { LANGUAGES, type UILanguage } from "@/lib/constants";
+import { handleRovingKeyDown } from "@/lib/a11y";
+import { s } from "./styles";
 
 export type { UILanguage };
 
 type Language = (typeof LANGUAGES)[number];
-
-const LANG_KEY_INDEX: Record<string, (_i: number) => number> = {
-  ArrowRight: (i) => (i + 1) % LANGUAGES.length,
-  ArrowDown: (i) => (i + 1) % LANGUAGES.length,
-  ArrowLeft: (i) => (i - 1 + LANGUAGES.length) % LANGUAGES.length,
-  ArrowUp: (i) => (i - 1 + LANGUAGES.length) % LANGUAGES.length,
-  Home: (_i) => 0,
-  End: (_i) => LANGUAGES.length - 1,
-};
 
 interface LanguageRadioProps {
   lang: Language;
@@ -29,26 +22,14 @@ function LanguageRadio({ lang, isSelected, onSelect, onKeyDown }: LanguageRadioP
     <chakra.button
       type="button"
       role="radio"
-      p={3}
-      borderWidth="2px"
-      borderColor="border"
-      boxShadow="brutal-sm"
-      fontWeight="700"
-      fontSize="sm"
-      textAlign="center"
-      cursor="pointer"
-      transition="transform 0.1s ease, box-shadow 0.1s ease"
-      _hover={{ transform: "translate(-2px, -2px)", boxShadow: "brutal" }}
-      _active={{ transform: "translate(2px, 2px)", boxShadow: "none" }}
-      bg={isSelected ? "primary" : "card"}
+      {...s.radio}
+      {...(isSelected ? s.radioSelected : s.radioUnselected)}
       aria-checked={isSelected}
       tabIndex={isSelected ? 0 : -1}
       onClick={onSelect}
       onKeyDown={onKeyDown}
     >
-      <Text fontSize="xl" display="block" mb={1}>
-        {lang.flag}
-      </Text>
+      <Text {...s.flagText}>{lang.flag}</Text>
       {lang.label}
     </chakra.button>
   );
@@ -65,54 +46,27 @@ export function LanguageSelector({ label, value, onChange, error }: LanguageSele
   const langGroupRef = useRef<HTMLDivElement>(null);
   const labelId = useId();
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent, index: number): void => {
-      const getIndex = LANG_KEY_INDEX[e.key];
-      if (!getIndex) return;
-      e.preventDefault();
-      const targetIndex = getIndex(index);
-      onChange(LANGUAGES[targetIndex].value);
-      const radios = langGroupRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
-      radios?.[targetIndex]?.focus();
-    },
-    [onChange]
-  );
-
   return (
     <Box w="100%">
-      <Text
-        id={labelId}
-        fontSize="sm"
-        fontWeight="700"
-        textTransform="uppercase"
-        letterSpacing="wider"
-        mb={2}
-      >
+      <Text id={labelId} {...s.label}>
         {label}
       </Text>
-      <Box
-        ref={langGroupRef}
-        role="radiogroup"
-        aria-labelledby={labelId}
-        display="grid"
-        gridTemplateColumns="repeat(3, 1fr)"
-        gap={2}
-      >
+      <Box ref={langGroupRef} role="radiogroup" aria-labelledby={labelId} {...s.radioGroup}>
         {LANGUAGES.map((lang, index) => (
           <LanguageRadio
             key={lang.value}
             lang={lang}
             isSelected={value === lang.value}
             onSelect={() => onChange(lang.value)}
-            onKeyDown={(e) => handleKeyDown(e, index)}
+            onKeyDown={(e) =>
+              handleRovingKeyDown(e, index, LANGUAGES.length, langGroupRef, (i) =>
+                onChange(LANGUAGES[i].value)
+              )
+            }
           />
         ))}
       </Box>
-      {error && (
-        <Text fontSize="sm" color="red.500" mt={1}>
-          {error}
-        </Text>
-      )}
+      {error && <Text {...s.error}>{error}</Text>}
     </Box>
   );
 }

--- a/components/LanguageSelector/styles.ts
+++ b/components/LanguageSelector/styles.ts
@@ -1,0 +1,45 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  label: {
+    fontSize: "sm",
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: "wider",
+    mb: 2,
+  },
+  radioGroup: {
+    display: "grid",
+    gridTemplateColumns: "repeat(3, 1fr)",
+    gap: 2,
+  },
+  radio: {
+    p: 3,
+    borderWidth: "2px",
+    borderColor: "border",
+    boxShadow: "brutal-sm",
+    fontWeight: "700",
+    fontSize: "sm",
+    textAlign: "center",
+    cursor: "pointer",
+    _motionSafe: {
+      transition: "transform 0.1s ease, box-shadow 0.1s ease",
+      _hover: { transform: "translate(-2px, -2px)" },
+      _active: { transform: "translate(2px, 2px)" },
+    },
+    _hover: { boxShadow: "brutal" },
+    _active: { boxShadow: "none" },
+  },
+  radioSelected: { bg: "primary" },
+  radioUnselected: { bg: "card" },
+  flagText: {
+    fontSize: "xl",
+    display: "block",
+    mb: 1,
+  },
+  error: {
+    fontSize: "sm",
+    color: "error",
+    mt: 1,
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/components/settings/DeleteAccountModal/index.tsx
+++ b/components/settings/DeleteAccountModal/index.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Text, chakra } from "@chakra-ui/react";
 import { useId } from "react";
 import { useTranslations } from "next-intl";
-import { Modal } from "@/components/ui/modal";
+import {
+  DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
 import { useForm } from "react-hook-form";
@@ -60,44 +67,56 @@ export function DeleteAccountModal({ open, onClose }: DeleteAccountModalProps) {
   };
 
   return (
-    <Modal
+    <DialogRoot
       open={open}
-      onClose={handleClose}
-      title={t("deleteModal.title")}
-      maxW="420px"
-      footer={
-        <Box {...s.footerActions}>
-          <Button
-            type="button"
-            variant="muted"
-            onClick={handleClose}
-            disabled={isPending}
-            {...s.footerBtn}
-          >
-            {t("deleteModal.cancelBtn")}
-          </Button>
-          <Button type="submit" form={formId} loading={isPending} {...s.deleteBtn}>
-            {t("deleteModal.confirmBtn")}
-          </Button>
-        </Box>
-      }
+      onOpenChange={(e) => !e.open && handleClose()}
+      scrollBehavior="inside"
+      placement="center"
     >
-      <Box as="form" id={formId} onSubmit={handleSubmit(onSubmit)}>
-        <Box {...s.warningBox}>
-          <Text {...s.warningText}>{t("deleteModal.warning")}</Text>
-        </Box>
+      <DialogContent {...s.content} maxW="420px" style={{ overscrollBehavior: "contain" }}>
+        <DialogHeader {...s.header}>
+          <DialogTitle {...s.title}>{t("deleteModal.title")}</DialogTitle>
+          <chakra.button type="button" onClick={handleClose} aria-label="Close" {...s.closeBtn}>
+            ✕
+          </chakra.button>
+        </DialogHeader>
 
-        <Box {...s.field}>
-          <PasswordInput
-            label={t("deleteModal.passwordLabel")}
-            placeholder={t("deleteModal.passwordPlaceholder")}
-            autoComplete="current-password"
-            error={errors.password?.message}
-            autoFocus
-            {...register("password")}
-          />
-        </Box>
-      </Box>
-    </Modal>
+        <DialogBody {...s.body}>
+          <Box as="form" id={formId} onSubmit={handleSubmit(onSubmit)}>
+            <Box {...s.warningBox}>
+              <Text {...s.warningText}>{t("deleteModal.warning")}</Text>
+            </Box>
+
+            <Box {...s.field}>
+              <PasswordInput
+                label={t("deleteModal.passwordLabel")}
+                placeholder={t("deleteModal.passwordPlaceholder")}
+                autoComplete="current-password"
+                error={errors.password?.message}
+                autoFocus
+                {...register("password")}
+              />
+            </Box>
+          </Box>
+        </DialogBody>
+
+        <DialogFooter {...s.footer}>
+          <Box {...s.footerActions}>
+            <Button
+              type="button"
+              variant="muted"
+              onClick={handleClose}
+              disabled={isPending}
+              {...s.footerBtn}
+            >
+              {t("deleteModal.cancelBtn")}
+            </Button>
+            <Button type="submit" form={formId} loading={isPending} {...s.deleteBtn}>
+              {t("deleteModal.confirmBtn")}
+            </Button>
+          </Box>
+        </DialogFooter>
+      </DialogContent>
+    </DialogRoot>
   );
 }

--- a/components/settings/DeleteAccountModal/index.tsx
+++ b/components/settings/DeleteAccountModal/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Text } from "@chakra-ui/react";
+import { useId } from "react";
 import { useTranslations } from "next-intl";
 import { Modal } from "@/components/ui/modal";
 import { PasswordInput } from "@/components/ui/password-input";
@@ -51,6 +52,8 @@ export function DeleteAccountModal({ open, onClose }: DeleteAccountModalProps) {
     deleteAccount(data.password);
   };
 
+  const formId = useId();
+
   const handleClose = () => {
     reset();
     onClose();
@@ -63,24 +66,23 @@ export function DeleteAccountModal({ open, onClose }: DeleteAccountModalProps) {
       title={t("deleteModal.title")}
       maxW="420px"
       footer={
-        <Box as="form" onSubmit={handleSubmit(onSubmit)} display="flex" gap={3} w="100%">
-          <Button type="button" variant="muted" onClick={handleClose} disabled={isPending} flex={1}>
+        <Box {...s.footerActions}>
+          <Button
+            type="button"
+            variant="muted"
+            onClick={handleClose}
+            disabled={isPending}
+            {...s.footerBtn}
+          >
             {t("deleteModal.cancelBtn")}
           </Button>
-          <Button
-            type="submit"
-            loading={isPending}
-            flex={1}
-            bg="red.500"
-            color="white"
-            _hover={{ bg: "red.600" }}
-          >
+          <Button type="submit" form={formId} loading={isPending} {...s.deleteBtn}>
             {t("deleteModal.confirmBtn")}
           </Button>
         </Box>
       }
     >
-      <Box>
+      <Box as="form" id={formId} onSubmit={handleSubmit(onSubmit)}>
         <Box {...s.warningBox}>
           <Text {...s.warningText}>{t("deleteModal.warning")}</Text>
         </Box>

--- a/components/settings/DeleteAccountModal/styles.ts
+++ b/components/settings/DeleteAccountModal/styles.ts
@@ -1,6 +1,65 @@
 import type { SystemStyleObject } from "@chakra-ui/react";
 
 export const s = {
+  content: {
+    bg: "card",
+    border: "3px solid black",
+    boxShadow: "brutal",
+    w: "100%",
+    maxH: "90vh",
+    p: 6,
+  },
+
+  header: {
+    p: 0,
+    mb: 6,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+  },
+
+  title: {
+    fontSize: "2xl",
+    fontWeight: "800",
+    textTransform: "uppercase" as const,
+    flex: 1,
+    pr: 4,
+  },
+
+  closeBtn: {
+    w: 10,
+    h: 10,
+    border: "3px solid black",
+    bg: "accent",
+    color: "white",
+    fontWeight: "900",
+    fontSize: "lg",
+    cursor: "pointer",
+    boxShadow: "brutal-sm",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    _motionSafe: {
+      transition: "transform 0.1s ease, box-shadow 0.1s ease",
+      _hover: { transform: "translate(-1px, -1px)", boxShadow: "brutal" },
+      _active: { transform: "translate(1px, 1px)", boxShadow: "none" },
+    },
+    _focusVisible: { outline: "3px solid", outlineColor: "ring", outlineOffset: "2px" },
+  },
+
+  body: {
+    p: 0,
+    overflowY: "auto" as const,
+    flex: "1",
+    minH: 0,
+  },
+
+  footer: {
+    p: 0,
+    mt: 4,
+  },
+
   warningBox: {
     bg: "red.50",
     border: "2px solid",

--- a/components/settings/DeleteAccountModal/styles.ts
+++ b/components/settings/DeleteAccountModal/styles.ts
@@ -18,4 +18,20 @@ export const s = {
   field: {
     mt: 4,
   },
+  footerActions: {
+    display: "flex",
+    gap: 3,
+    w: "100%",
+  },
+
+  footerBtn: {
+    flex: 1,
+  },
+
+  deleteBtn: {
+    flex: 1,
+    bg: "red.500",
+    color: "white",
+    _hover: { bg: "red.600" },
+  },
 } satisfies Record<string, SystemStyleObject>;


### PR DESCRIPTION
## Summary

- `LanguageSelector`: criar `styles.ts`, remover `css={}` e `@media` inline em `_hover`/`_active`, substituir por `_motionSafe`; extrair todos inline props para `styles.ts`
- `DeleteAccountModal`: mover inline props do footer (`display/gap/w/flex/bg/color/_hover`) para `styles.ts`; fix form/id pattern — submit button no footer usa `form={formId}`, form no body do modal
- `settings.styles.ts`: `textWrap: "balance"` nos headings de seção, `_motionSafe` na transição da barra de uso
- `settings/page.tsx`: reset form com dados atualizados após save, `autoComplete="name"` no campo nome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Style**
  * Ajustados estilos de tipografia e transições para melhor consistência visual.

* **Refactor**
  * Melhorado o fluxo de salvamento de configurações de perfil.
  * Otimizada navegação por teclado no seletor de idioma.
  * Reestruturado formulário modal de exclusão de conta para melhor acessibilidade.
  * Aprimorada experiência do campo de nome com sugestões de preenchimento automático.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->