### PR TITLE
feat(pronunciation): pronunciation practice UI for language habits

### DIFF
--- a/app/[locale]/(app)/analytics/page.tsx
+++ b/app/[locale]/(app)/analytics/page.tsx
@@ -10,6 +10,7 @@ import { JournalMetrics } from "@/components/Analytics/JournalMetrics";
 import { MoodEnergyChart } from "@/components/Analytics/MoodEnergyChart";
 import { ScoreTimeline } from "@/components/Analytics/ScoreTimeline";
 import { StreakCalendar } from "@/components/Analytics/StreakCalendar";
+import { WordCloudErrors } from "@/components/Analytics/WordCloudErrors";
 import { useAnalyticsSummary } from "@/lib/hooks/useAnalytics";
 import { s } from "./styles";
 
@@ -123,7 +124,13 @@ export default function AnalyticsPage() {
                     <Box {...s.sectionGrid}>
                       <StreakCalendar habit={selectedHabit} logs={selectedHabit.logs} />
                       {isLanguageHabit ? (
-                        <ScoreTimeline habit={selectedHabit} />
+                        <>
+                          <ScoreTimeline habit={selectedHabit} />
+                          <WordCloudErrors
+                            habitId={selectedHabit.id}
+                            habitColor={selectedHabit.color}
+                          />
+                        </>
                       ) : (
                         <JournalMetrics global={data.global} />
                       )}

--- a/app/[locale]/(app)/analytics/page.tsx
+++ b/app/[locale]/(app)/analytics/page.tsx
@@ -11,6 +11,7 @@ import { MoodEnergyChart } from "@/components/Analytics/MoodEnergyChart";
 import { ScoreTimeline } from "@/components/Analytics/ScoreTimeline";
 import { StreakCalendar } from "@/components/Analytics/StreakCalendar";
 import { WordCloudErrors } from "@/components/Analytics/WordCloudErrors";
+import type { ApiColor } from "@/lib/constants";
 import { useAnalyticsSummary } from "@/lib/hooks/useAnalytics";
 import { s } from "./styles";
 
@@ -128,7 +129,7 @@ export default function AnalyticsPage() {
                           <ScoreTimeline habit={selectedHabit} />
                           <WordCloudErrors
                             habitId={selectedHabit.id}
-                            habitColor={selectedHabit.color}
+                            habitColor={selectedHabit.color as ApiColor}
                           />
                         </>
                       ) : (

--- a/app/[locale]/(app)/analytics/page.tsx
+++ b/app/[locale]/(app)/analytics/page.tsx
@@ -11,7 +11,6 @@ import { MoodEnergyChart } from "@/components/Analytics/MoodEnergyChart";
 import { ScoreTimeline } from "@/components/Analytics/ScoreTimeline";
 import { StreakCalendar } from "@/components/Analytics/StreakCalendar";
 import { WordCloudErrors } from "@/components/Analytics/WordCloudErrors";
-import type { ApiColor } from "@/lib/constants";
 import { useAnalyticsSummary } from "@/lib/hooks/useAnalytics";
 import { s } from "./styles";
 
@@ -129,7 +128,7 @@ export default function AnalyticsPage() {
                           <ScoreTimeline habit={selectedHabit} />
                           <WordCloudErrors
                             habitId={selectedHabit.id}
-                            habitColor={selectedHabit.color as ApiColor}
+                            habitColor={selectedHabit.color}
                           />
                         </>
                       ) : (

--- a/app/[locale]/(app)/daily-lab/page.tsx
+++ b/app/[locale]/(app)/daily-lab/page.tsx
@@ -64,6 +64,7 @@ export default function DailyLabPage() {
             journalEntries={journalEntries}
             selectedHabitId={resolvedHabitId}
             onSelect={setSelectedHabitId}
+            today={today}
           />
 
           {activeHabits.length > 0 && selectedHabit && (

--- a/components/Analytics/WordCloudErrors/index.tsx
+++ b/components/Analytics/WordCloudErrors/index.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Box, Text } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { useWordCloud } from "@/lib/hooks/useWordCloud";
+import { toChakraColor } from "@/lib/habit-utils";
+import { s } from "./styles";
+
+interface WordCloudErrorsProps {
+  habitId: string;
+  habitColor: string;
+}
+
+function calcFontSize(frequency: number, min: number, max: number): string {
+  const range = max - min || 1;
+  const scale = 0.875 + ((frequency - min) / range) * 1.125;
+  return `${scale.toFixed(3)}rem`;
+}
+
+export function WordCloudErrors({ habitId, habitColor }: WordCloudErrorsProps) {
+  const t = useTranslations("pronunciation");
+  const { data: items = [] } = useWordCloud(habitId);
+
+  if (items.length === 0) return null;
+
+  const frequencies = items.map((i) => i.frequency);
+  const minF = Math.min(...frequencies);
+  const maxF = Math.max(...frequencies);
+  const color = toChakraColor(habitColor);
+
+  return (
+    <Box {...s.wrapper}>
+      <Text {...s.title}>{t("wordCloud.title")}</Text>
+      <Box {...s.cloud}>
+        {items.map((item) => {
+          const fs = calcFontSize(item.frequency, minF, maxF);
+          return (
+            <Text key={item.word} fontWeight="800" color={color} fontSize={fs} data-fontsize={fs}>
+              {item.word}
+            </Text>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/components/Analytics/WordCloudErrors/index.tsx
+++ b/components/Analytics/WordCloudErrors/index.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Skeleton, Text } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { useWordCloud } from "@/lib/hooks/useWordCloud";
 import { toChakraColor } from "@/lib/habit-utils";
+import type { ApiColor } from "@/lib/constants";
 import { s } from "./styles";
 
 interface WordCloudErrorsProps {
   habitId: string;
-  habitColor: string;
+  /** Must be a valid ApiColor value (e.g. "bg-surface-mint") */
+  habitColor: ApiColor;
 }
 
 const MIN_REM = 0.8;
@@ -22,8 +24,9 @@ function calcFontSize(frequency: number, min: number, max: number): string {
 
 export function WordCloudErrors({ habitId, habitColor }: WordCloudErrorsProps) {
   const t = useTranslations("pronunciation");
-  const { data: items = [] } = useWordCloud(habitId);
+  const { data: items = [], isLoading } = useWordCloud(habitId);
 
+  if (isLoading) return <Skeleton h={10} w="100%" />;
   if (items.length === 0) return null;
 
   const frequencies = items.map((i) => i.frequency);
@@ -35,11 +38,11 @@ export function WordCloudErrors({ habitId, habitColor }: WordCloudErrorsProps) {
     <Box {...s.wrapper}>
       <Text {...s.title}>{t("wordCloud.title")}</Text>
       <Box {...s.cloud}>
-        {items.map((item) => {
+        {items.map((item, i) => {
           const fs = calcFontSize(item.frequency, minF, maxF);
           return (
             <Text
-              key={item.word}
+              key={`${item.word}-${i}`}
               fontWeight="800"
               color={color}
               fontSize={fs}

--- a/components/Analytics/WordCloudErrors/index.tsx
+++ b/components/Analytics/WordCloudErrors/index.tsx
@@ -25,7 +25,7 @@ export function WordCloudErrors({ habitId, habitColor }: WordCloudErrorsProps) {
   const t = useTranslations("pronunciation");
   const { data: items = [], isLoading } = useWordCloud(habitId);
 
-  if (isLoading) return <Skeleton h={10} w="100%" />;
+  if (isLoading) return <Skeleton data-testid="word-cloud-skeleton" h={10} w="100%" />;
   if (items.length === 0) return null;
 
   const frequencies = items.map((i) => i.frequency);

--- a/components/Analytics/WordCloudErrors/index.tsx
+++ b/components/Analytics/WordCloudErrors/index.tsx
@@ -11,9 +11,12 @@ interface WordCloudErrorsProps {
   habitColor: string;
 }
 
+const MIN_REM = 0.8;
+const MAX_REM = 2;
+
 function calcFontSize(frequency: number, min: number, max: number): string {
-  const range = max - min || 1;
-  const scale = 0.875 + ((frequency - min) / range) * 1.125;
+  if (min === max) return `${MAX_REM}rem`;
+  const scale = MIN_REM + ((frequency - min) / (max - min)) * (MAX_REM - MIN_REM);
   return `${scale.toFixed(3)}rem`;
 }
 
@@ -35,7 +38,14 @@ export function WordCloudErrors({ habitId, habitColor }: WordCloudErrorsProps) {
         {items.map((item) => {
           const fs = calcFontSize(item.frequency, minF, maxF);
           return (
-            <Text key={item.word} fontWeight="800" color={color} fontSize={fs} data-fontsize={fs}>
+            <Text
+              key={item.word}
+              fontWeight="800"
+              color={color}
+              fontSize={fs}
+              data-fontsize={fs}
+              aria-label={`${item.word}: ${item.frequency}`}
+            >
               {item.word}
             </Text>
           );

--- a/components/Analytics/WordCloudErrors/index.tsx
+++ b/components/Analytics/WordCloudErrors/index.tsx
@@ -4,13 +4,12 @@ import { Box, Skeleton, Text } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { useWordCloud } from "@/lib/hooks/useWordCloud";
 import { toChakraColor } from "@/lib/habit-utils";
-import type { ApiColor } from "@/lib/constants";
 import { s } from "./styles";
 
 interface WordCloudErrorsProps {
   habitId: string;
-  /** Must be a valid ApiColor value (e.g. "bg-surface-mint") */
-  habitColor: ApiColor;
+  /** Chakra color token already transformed by toChakraColor (e.g. "surface.mint") */
+  habitColor: string;
 }
 
 const MIN_REM = 0.8;
@@ -47,7 +46,7 @@ export function WordCloudErrors({ habitId, habitColor }: WordCloudErrorsProps) {
               color={color}
               fontSize={fs}
               data-fontsize={fs}
-              aria-label={`${item.word}: ${item.frequency}`}
+              aria-label={t("wordCloud.itemLabel", { word: item.word, count: item.frequency })}
             >
               {item.word}
             </Text>

--- a/components/Analytics/WordCloudErrors/styles.ts
+++ b/components/Analytics/WordCloudErrors/styles.ts
@@ -1,0 +1,30 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  wrapper: {
+    minW: 0,
+    w: "100%",
+    border: "0.1875rem solid black",
+    boxShadow: "brutal",
+    p: { base: 4, md: 6 },
+    pt: { base: 5, md: 7 },
+    display: "flex",
+    flexDirection: "column",
+    gridColumn: { base: "auto", md: "span 2" },
+  },
+
+  title: {
+    fontSize: { base: "lg", md: "xl" },
+    fontWeight: "800",
+    textTransform: "uppercase",
+    letterSpacing: "wider",
+    mb: { base: 3, md: 4 },
+  },
+
+  cloud: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 2,
+    alignItems: "baseline",
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/components/daily-lab/HabitChecklist/index.tsx
+++ b/components/daily-lab/HabitChecklist/index.tsx
@@ -1,18 +1,27 @@
 "use client";
 
-import { Box, Text, chakra } from "@chakra-ui/react";
+import { useState } from "react";
+import { Box, Button, Text, chakra } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
+import { LuMic } from "react-icons/lu";
 import type { Habit, SkillBuildingPhase, TrackingCoachedPhase } from "@/types/habits";
 import { SKILL_ICONS } from "@/lib/habit-utils";
 import type { JournalEntry } from "@/types/journal";
 import { getCurrentPhase } from "@/lib/habit-utils";
+import { PronunciationModal } from "@/components/daily-lab/PronunciationModal";
 import { s } from "./styles";
+
+type ModalState = {
+  habit: Habit;
+  originalText: string;
+} | null;
 
 interface HabitChecklistProps {
   habits: Habit[];
   journalEntries: JournalEntry[];
   selectedHabitId: string | null;
   onSelect: (_id: string) => void;
+  today: string;
 }
 
 export function HabitChecklist({
@@ -20,93 +29,125 @@ export function HabitChecklist({
   journalEntries,
   selectedHabitId,
   onSelect,
+  today,
 }: HabitChecklistProps) {
   const t = useTranslations("dailyLab");
   const tHabits = useTranslations("habits");
+  const [modalState, setModalState] = useState<ModalState>(null);
+
   const habitsWithFeedback = new Set(
     journalEntries.filter((e) => e.aiFeedback != null).map((e) => e.habitId)
   );
 
   return (
-    <Box {...s.section}>
-      <Text {...s.sectionTitle}>
-        {t("checklist.sectionTitle", {
-          completed: habits.filter((h) => h.completed_today || habitsWithFeedback.has(h.id)).length,
-          total: habits.length,
-        })}
-      </Text>
+    <>
+      <Box {...s.section}>
+        <Text {...s.sectionTitle}>
+          {t("checklist.sectionTitle", {
+            completed: habits.filter((h) => h.completed_today || habitsWithFeedback.has(h.id))
+              .length,
+            total: habits.length,
+          })}
+        </Text>
 
-      <Box {...s.habitList}>
-        {habits.map((habit) => {
-          const hasFeedback = habitsWithFeedback.has(habit.id);
-          const completed = habit.completed_today || hasFeedback;
-          const selected = habit.id === selectedHabitId;
-          const isActive = completed || selected;
-          const phase = getCurrentPhase(habit);
+        <Box {...s.habitList}>
+          {habits.map((habit) => {
+            const hasFeedback = habitsWithFeedback.has(habit.id);
+            const completed = habit.completed_today || hasFeedback;
+            const selected = habit.id === selectedHabitId;
+            const isActive = completed || selected;
+            const phase = getCurrentPhase(habit);
 
-          return (
-            <Box key={habit.id}>
-              <chakra.button
-                type="button"
-                aria-pressed={selected}
-                aria-label={`${habit.name}${hasFeedback ? ` — ${t("checklist.doneToday")}` : ""}`}
-                onClick={() => onSelect(habit.id)}
-                {...s.habitCard}
-                cursor="pointer"
-                bg={isActive ? habit.color : "card"}
-                boxShadow={isActive ? "none" : "brutal"}
-                _motionSafe={isActive ? { transform: "translate(4px, 4px)" } : undefined}
-              >
-                <Box {...s.habitRow}>
-                  <Text {...s.habitIcon}>{habit.icon}</Text>
-                  <Box {...s.habitInfo}>
-                    <Text {...s.habitName}>{habit.name}</Text>
-                    <Box {...s.habitMeta}>
-                      <Box {...s.skillBadge}>
-                        {SKILL_ICONS[habit.target_skill]}{" "}
-                        {tHabits(`skills.${habit.target_skill}.name`)}
-                      </Box>
-                      <Text {...s.streakText}>
-                        {t("checklist.day", { current: habit.current_day })} · {habit.streak}🔥
-                      </Text>
-                    </Box>
-                  </Box>
-                  <Box
-                    aria-hidden="true"
-                    {...s.checkboxIndicator}
-                    bg={hasFeedback ? "black" : "card"}
-                  >
-                    {hasFeedback && <Text {...s.checkboxIcon}>✓</Text>}
-                    {selected && !hasFeedback && <Text {...s.checkboxDashIcon}>–</Text>}
-                  </Box>
-                </Box>
-              </chakra.button>
-
-              {phase && (
-                <Box {...s.planCard}>
-                  <Text {...s.planHeader}>
-                    {t("checklist.todaysFocus", { phase: phase.phase, theme: phase.theme })}
-                  </Text>
-                  {"daily_tasks" in phase ? (
-                    <Box {...s.taskList}>
-                      {(phase as SkillBuildingPhase).daily_tasks.map((task, i) => (
-                        <Text key={i} {...s.taskItem}>
-                          → {task}
+            return (
+              <Box key={habit.id}>
+                <chakra.button
+                  type="button"
+                  aria-pressed={selected}
+                  aria-label={`${habit.name}${hasFeedback ? ` — ${t("checklist.doneToday")}` : ""}`}
+                  onClick={() => onSelect(habit.id)}
+                  {...s.habitCard}
+                  cursor="pointer"
+                  bg={isActive ? habit.color : "card"}
+                  boxShadow={isActive ? "none" : "brutal"}
+                  _motionSafe={isActive ? { transform: "translate(4px, 4px)" } : undefined}
+                >
+                  <Box {...s.habitRow}>
+                    <Text {...s.habitIcon}>{habit.icon}</Text>
+                    <Box {...s.habitInfo}>
+                      <Text {...s.habitName}>{habit.name}</Text>
+                      <Box {...s.habitMeta}>
+                        <Box {...s.skillBadge}>
+                          {SKILL_ICONS[habit.target_skill]}{" "}
+                          {tHabits(`skills.${habit.target_skill}.name`)}
+                        </Box>
+                        <Text {...s.streakText}>
+                          {t("checklist.day", { current: habit.current_day })} · {habit.streak}🔥
                         </Text>
-                      ))}
+                      </Box>
                     </Box>
-                  ) : (
-                    <Box>
-                      <Text {...s.taskItem}>{(phase as TrackingCoachedPhase).weekly_focus}</Text>
-                      <Text {...s.tipText}>💡 {(phase as TrackingCoachedPhase).tip}</Text>
+                    <Box
+                      aria-hidden="true"
+                      {...s.checkboxIndicator}
+                      bg={hasFeedback ? "black" : "card"}
+                    >
+                      {hasFeedback && <Text {...s.checkboxIcon}>✓</Text>}
+                      {selected && !hasFeedback && <Text {...s.checkboxDashIcon}>–</Text>}
                     </Box>
-                  )}
-                </Box>
-              )}
-            </Box>
-          );
-        })}
+                  </Box>
+                </chakra.button>
+
+                {phase && (
+                  <Box {...s.planCard}>
+                    <Text {...s.planHeader}>
+                      {t("checklist.todaysFocus", { phase: phase.phase, theme: phase.theme })}
+                    </Text>
+                    {"daily_tasks" in phase ? (
+                      <Box {...s.taskList}>
+                        {(phase as SkillBuildingPhase).daily_tasks.map((task, i) => (
+                          <Text key={i} {...s.taskItem}>
+                            → {task}
+                          </Text>
+                        ))}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          mt={2}
+                          onClick={() =>
+                            setModalState({
+                              habit,
+                              originalText:
+                                (phase as SkillBuildingPhase).journal_prompt ??
+                                (phase as SkillBuildingPhase).daily_tasks[0],
+                            })
+                          }
+                        >
+                          <LuMic />
+                          {t("checklist.practiceButton")}
+                        </Button>
+                      </Box>
+                    ) : (
+                      <Box>
+                        <Text {...s.taskItem}>{(phase as TrackingCoachedPhase).weekly_focus}</Text>
+                        <Text {...s.tipText}>💡 {(phase as TrackingCoachedPhase).tip}</Text>
+                      </Box>
+                    )}
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
+        </Box>
       </Box>
-    </Box>
+
+      {modalState && (
+        <PronunciationModal
+          open={true}
+          onClose={() => setModalState(null)}
+          habit={modalState.habit}
+          originalText={modalState.originalText}
+          entryDate={today}
+        />
+      )}
+    </>
   );
 }

--- a/components/daily-lab/HabitChecklist/index.tsx
+++ b/components/daily-lab/HabitChecklist/index.tsx
@@ -108,22 +108,24 @@ export function HabitChecklist({
                             → {task}
                           </Text>
                         ))}
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          mt={2}
-                          onClick={() =>
-                            setModalState({
-                              habit,
-                              originalText:
-                                (phase as SkillBuildingPhase).journal_prompt ??
-                                (phase as SkillBuildingPhase).daily_tasks[0],
-                            })
-                          }
-                        >
-                          <LuMic />
-                          {t("checklist.practiceButton")}
-                        </Button>
+                        {(() => {
+                          const skillPhase = phase as SkillBuildingPhase;
+                          const originalText =
+                            skillPhase.journal_prompt?.trim() ||
+                            skillPhase.daily_tasks[0]?.trim() ||
+                            null;
+                          return habit.plan_status === "ready" && originalText ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              mt={2}
+                              onClick={() => setModalState({ habit, originalText })}
+                            >
+                              <LuMic />
+                              {t("checklist.practiceButton")}
+                            </Button>
+                          ) : null;
+                        })()}
                       </Box>
                     ) : (
                       <Box>

--- a/components/daily-lab/HabitChecklist/index.tsx
+++ b/components/daily-lab/HabitChecklist/index.tsx
@@ -57,6 +57,12 @@ export function HabitChecklist({
             const selected = habit.id === selectedHabitId;
             const isActive = completed || selected;
             const phase = getCurrentPhase(habit);
+            const skillPhase =
+              phase && "daily_tasks" in phase ? (phase as SkillBuildingPhase) : null;
+            const practiceText =
+              skillPhase && habit.plan_status === "ready"
+                ? skillPhase.journal_prompt?.trim() || skillPhase.daily_tasks[0]?.trim() || null
+                : null;
 
             return (
               <Box key={habit.id}>
@@ -101,36 +107,25 @@ export function HabitChecklist({
                     <Text {...s.planHeader}>
                       {t("checklist.todaysFocus", { phase: phase.phase, theme: phase.theme })}
                     </Text>
-                    {"daily_tasks" in phase ? (
-                      (() => {
-                        const skillPhase = phase as SkillBuildingPhase;
-                        const practiceText =
-                          habit.plan_status === "ready"
-                            ? skillPhase.journal_prompt?.trim() ||
-                              skillPhase.daily_tasks[0]?.trim() ||
-                              null
-                            : null;
-                        return (
-                          <Box {...s.taskList}>
-                            {skillPhase.daily_tasks.map((task, i) => (
-                              <Text key={i} {...s.taskItem}>
-                                → {task}
-                              </Text>
-                            ))}
-                            {practiceText && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                mt={2}
-                                onClick={() => setModalState({ habit, originalText: practiceText })}
-                              >
-                                <LuMic />
-                                {t("checklist.practiceButton")}
-                              </Button>
-                            )}
-                          </Box>
-                        );
-                      })()
+                    {skillPhase ? (
+                      <Box {...s.taskList}>
+                        {skillPhase.daily_tasks.map((task, i) => (
+                          <Text key={i} {...s.taskItem}>
+                            → {task}
+                          </Text>
+                        ))}
+                        {practiceText && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            mt={2}
+                            onClick={() => setModalState({ habit, originalText: practiceText })}
+                          >
+                            <LuMic />
+                            {t("checklist.practiceButton")}
+                          </Button>
+                        )}
+                      </Box>
                     ) : (
                       <Box>
                         <Text {...s.taskItem}>{(phase as TrackingCoachedPhase).weekly_focus}</Text>

--- a/components/daily-lab/HabitChecklist/index.tsx
+++ b/components/daily-lab/HabitChecklist/index.tsx
@@ -102,31 +102,35 @@ export function HabitChecklist({
                       {t("checklist.todaysFocus", { phase: phase.phase, theme: phase.theme })}
                     </Text>
                     {"daily_tasks" in phase ? (
-                      <Box {...s.taskList}>
-                        {(phase as SkillBuildingPhase).daily_tasks.map((task, i) => (
-                          <Text key={i} {...s.taskItem}>
-                            → {task}
-                          </Text>
-                        ))}
-                        {(() => {
-                          const skillPhase = phase as SkillBuildingPhase;
-                          const originalText =
-                            skillPhase.journal_prompt?.trim() ||
-                            skillPhase.daily_tasks[0]?.trim() ||
-                            null;
-                          return habit.plan_status === "ready" && originalText ? (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              mt={2}
-                              onClick={() => setModalState({ habit, originalText })}
-                            >
-                              <LuMic />
-                              {t("checklist.practiceButton")}
-                            </Button>
-                          ) : null;
-                        })()}
-                      </Box>
+                      (() => {
+                        const skillPhase = phase as SkillBuildingPhase;
+                        const practiceText =
+                          habit.plan_status === "ready"
+                            ? skillPhase.journal_prompt?.trim() ||
+                              skillPhase.daily_tasks[0]?.trim() ||
+                              null
+                            : null;
+                        return (
+                          <Box {...s.taskList}>
+                            {skillPhase.daily_tasks.map((task, i) => (
+                              <Text key={i} {...s.taskItem}>
+                                → {task}
+                              </Text>
+                            ))}
+                            {practiceText && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                mt={2}
+                                onClick={() => setModalState({ habit, originalText: practiceText })}
+                              >
+                                <LuMic />
+                                {t("checklist.practiceButton")}
+                              </Button>
+                            )}
+                          </Box>
+                        );
+                      })()
                     ) : (
                       <Box>
                         <Text {...s.taskItem}>{(phase as TrackingCoachedPhase).weekly_focus}</Text>

--- a/components/daily-lab/PronunciationModal/index.tsx
+++ b/components/daily-lab/PronunciationModal/index.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Box, Button, Spinner, Text } from "@chakra-ui/react";
+import { useEffect, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { LuMic, LuSquare } from "react-icons/lu";
+import {
+  DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogCloseTrigger,
+} from "@/components/ui/dialog";
+import { PronunciationResult } from "@/components/daily-lab/PronunciationResult";
+import { usePronunciationRecorder } from "@/lib/hooks/usePronunciationRecorder";
+import { usePronunciation } from "@/lib/hooks/usePronunciation";
+import type { Habit } from "@/types/habits";
+import { s } from "./styles";
+
+interface PronunciationModalProps {
+  open: boolean;
+  onClose: () => void;
+  habit: Habit;
+  originalText: string;
+  entryDate: string;
+}
+
+export function PronunciationModal({
+  open,
+  onClose,
+  habit,
+  originalText,
+  entryDate,
+}: PronunciationModalProps) {
+  const t = useTranslations("pronunciation");
+  const recorder = usePronunciationRecorder();
+  const pronunciation = usePronunciation();
+
+  function handleClose() {
+    recorder.reset();
+    pronunciation.reset();
+    onClose();
+  }
+
+  function handleRetry() {
+    recorder.reset();
+    pronunciation.reset();
+  }
+
+  function handleAnalyze() {
+    if (!recorder.audioBlob) return;
+    pronunciation.analyze({
+      blob: recorder.audioBlob,
+      mimeType: recorder.mimeType,
+      habitId: habit.id,
+      originalText,
+      entryDate,
+    });
+  }
+
+  const audioSrc = useMemo(() => {
+    if (!recorder.audioBlob) return null;
+    return URL.createObjectURL(recorder.audioBlob);
+  }, [recorder.audioBlob]);
+
+  useEffect(() => {
+    return () => {
+      if (audioSrc) URL.revokeObjectURL(audioSrc);
+    };
+  }, [audioSrc]);
+
+  const showResult = !!pronunciation.result;
+  const showLoading = pronunciation.isLoading;
+
+  return (
+    <DialogRoot
+      open={open}
+      onOpenChange={({ open: isOpen }) => {
+        if (!isOpen) handleClose();
+      }}
+      placement="center"
+    >
+      <DialogContent maxW="lg">
+        <DialogHeader>
+          <DialogTitle>{t("modalTitle")}</DialogTitle>
+          <DialogCloseTrigger />
+        </DialogHeader>
+
+        <DialogBody pb={6}>
+          {!recorder.isSupported ? (
+            <Box {...s.unsupportedBox}>
+              <Text {...s.unsupportedText}>{t("browserNotSupported")}</Text>
+            </Box>
+          ) : showResult ? (
+            <PronunciationResult
+              result={pronunciation.result!}
+              originalText={originalText}
+              onRetry={handleRetry}
+            />
+          ) : showLoading ? (
+            <Box {...s.loadingBox}>
+              <Spinner size="xl" borderWidth="4px" color="primary" />
+              <Text {...s.loadingText}>
+                {pronunciation.isLoading ? t("analyzing") : t("uploading")}
+              </Text>
+            </Box>
+          ) : (
+            <>
+              <Box {...s.referenceBox}>
+                <Text {...s.referenceLabel}>{t("referenceText")}</Text>
+                <Text {...s.referenceText}>{originalText}</Text>
+              </Box>
+
+              {recorder.state === "recording" && (
+                <Box {...s.recordingIndicator}>
+                  <Box {...s.recordingDot} />
+                  <Text {...s.recordingText}>{t("record")}</Text>
+                </Box>
+              )}
+
+              {audioSrc && recorder.state === "recorded" && (
+                <Box {...s.audioPlayerWrapper}>
+                  <audio controls src={audioSrc} style={{ width: "100%" }} />
+                </Box>
+              )}
+
+              <Box {...s.controls}>
+                {recorder.state === "idle" && (
+                  <Button colorPalette="red" onClick={recorder.start}>
+                    <LuMic />
+                    {t("record")}
+                  </Button>
+                )}
+
+                {recorder.state === "recording" && (
+                  <Button colorPalette="red" variant="outline" onClick={recorder.stop}>
+                    <LuSquare />
+                    {t("stop")}
+                  </Button>
+                )}
+
+                {recorder.state === "recorded" && (
+                  <>
+                    <Button variant="outline" size="sm" onClick={recorder.reset}>
+                      <LuMic />
+                      {t("record")}
+                    </Button>
+                    <Button onClick={handleAnalyze} disabled={!recorder.audioBlob}>
+                      {t("analyze")}
+                    </Button>
+                  </>
+                )}
+              </Box>
+            </>
+          )}
+        </DialogBody>
+      </DialogContent>
+    </DialogRoot>
+  );
+}

--- a/components/daily-lab/PronunciationModal/index.tsx
+++ b/components/daily-lab/PronunciationModal/index.tsx
@@ -101,9 +101,7 @@ export function PronunciationModal({
           ) : showLoading ? (
             <Box {...s.loadingBox}>
               <Spinner size="xl" borderWidth="4px" color="primary" />
-              <Text {...s.loadingText}>
-                {pronunciation.isLoading ? t("analyzing") : t("uploading")}
-              </Text>
+              <Text {...s.loadingText}>{t("analyzing")}</Text>
             </Box>
           ) : (
             <>

--- a/components/daily-lab/PronunciationModal/index.tsx
+++ b/components/daily-lab/PronunciationModal/index.tsx
@@ -122,7 +122,7 @@ export function PronunciationModal({
                   <audio
                     controls
                     src={audioSrc}
-                    aria-label={t("listening")}
+                    aria-label={t("audioPreview")}
                     style={{ width: "100%" }}
                   />
                 </Box>

--- a/components/daily-lab/PronunciationModal/index.tsx
+++ b/components/daily-lab/PronunciationModal/index.tsx
@@ -119,7 +119,12 @@ export function PronunciationModal({
 
               {audioSrc && recorder.state === "recorded" && (
                 <Box {...s.audioPlayerWrapper}>
-                  <audio controls src={audioSrc} style={{ width: "100%" }} />
+                  <audio
+                    controls
+                    src={audioSrc}
+                    aria-label={t("listening")}
+                    style={{ width: "100%" }}
+                  />
                 </Box>
               )}
 

--- a/components/daily-lab/PronunciationModal/index.tsx
+++ b/components/daily-lab/PronunciationModal/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Button, Spinner, Text } from "@chakra-ui/react";
+import { Box, Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
 import { useEffect, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { LuMic, LuSquare } from "react-icons/lu";
@@ -99,10 +99,10 @@ export function PronunciationModal({
               onRetry={handleRetry}
             />
           ) : showLoading ? (
-            <Box {...s.loadingBox}>
+            <VStack role="status" aria-live="polite" gap={3} py={6}>
               <Spinner size="xl" borderWidth="4px" color="primary" />
               <Text {...s.loadingText}>{t("analyzing")}</Text>
-            </Box>
+            </VStack>
           ) : (
             <>
               <Box {...s.referenceBox}>
@@ -111,10 +111,10 @@ export function PronunciationModal({
               </Box>
 
               {recorder.state === "recording" && (
-                <Box {...s.recordingIndicator}>
+                <HStack gap={2} justify="center" py={2}>
                   <Box {...s.recordingDot} />
                   <Text {...s.recordingText}>{t("record")}</Text>
-                </Box>
+                </HStack>
               )}
 
               {audioSrc && recorder.state === "recorded" && (

--- a/components/daily-lab/PronunciationModal/styles.ts
+++ b/components/daily-lab/PronunciationModal/styles.ts
@@ -1,0 +1,86 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  referenceBox: {
+    border: "2px solid black",
+    bg: "card",
+    p: 4,
+    mb: 4,
+  },
+
+  referenceLabel: {
+    fontSize: "xs",
+    fontWeight: "bold",
+    textTransform: "uppercase" as const,
+    letterSpacing: "wider",
+    color: "mutedFg",
+    mb: 2,
+  },
+
+  referenceText: {
+    fontSize: "md",
+    fontWeight: "600",
+    lineHeight: "1.6",
+  },
+
+  controls: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 3,
+    py: 4,
+  },
+
+  recordingIndicator: {
+    display: "flex",
+    alignItems: "center",
+    gap: 2,
+    justifyContent: "center",
+    py: 2,
+  },
+
+  recordingDot: {
+    w: 3,
+    h: 3,
+    borderRadius: "full",
+    bg: "red.500",
+    animation: "pulse 1s ease-in-out infinite",
+  },
+
+  recordingText: {
+    fontSize: "sm",
+    fontWeight: "600",
+    color: "red.600",
+  },
+
+  audioPlayerWrapper: {
+    w: "100%",
+    mb: 3,
+  },
+
+  loadingBox: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 3,
+    py: 6,
+  },
+
+  loadingText: {
+    fontSize: "sm",
+    fontWeight: "600",
+    color: "mutedFg",
+  },
+
+  unsupportedBox: {
+    border: "2px solid black",
+    bg: "surface.coral",
+    p: 4,
+    textAlign: "center" as const,
+  },
+
+  unsupportedText: {
+    fontSize: "sm",
+    fontWeight: "600",
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/components/daily-lab/PronunciationModal/styles.ts
+++ b/components/daily-lab/PronunciationModal/styles.ts
@@ -31,14 +31,6 @@ export const s = {
     py: 4,
   },
 
-  recordingIndicator: {
-    display: "flex",
-    alignItems: "center",
-    gap: 2,
-    justifyContent: "center",
-    py: 2,
-  },
-
   recordingDot: {
     w: 3,
     h: 3,
@@ -57,14 +49,6 @@ export const s = {
   audioPlayerWrapper: {
     w: "100%",
     mb: 3,
-  },
-
-  loadingBox: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    gap: 3,
-    py: 6,
   },
 
   loadingText: {

--- a/components/daily-lab/PronunciationModal/styles.ts
+++ b/components/daily-lab/PronunciationModal/styles.ts
@@ -44,6 +44,7 @@ export const s = {
     h: 3,
     borderRadius: "full",
     bg: "red.500",
+    // 1s is intentional: faster pulse gives clear real-time recording feedback
     animation: "pulse 1s ease-in-out infinite",
   },
 

--- a/components/daily-lab/PronunciationResult/index.tsx
+++ b/components/daily-lab/PronunciationResult/index.tsx
@@ -27,12 +27,20 @@ function tokenizeWords(text: string): string[] {
     .map((w) => w.replace(/[^\p{L}\p{N}]+$/u, "").replace(/^[^\p{L}\p{N}]+/u, ""));
 }
 
+function buildCountMap(words: string[]): Map<string, number> {
+  return words.reduce((acc, word) => {
+    const key = word.toLowerCase();
+    acc.set(key, (acc.get(key) ?? 0) + 1);
+    return acc;
+  }, new Map<string, number>());
+}
+
 export function PronunciationResult({ result, originalText, onRetry }: PronunciationResultProps) {
   const t = useTranslations("pronunciation");
   const pct = Math.round(result.score * 100);
 
-  const correctSet = new Set(result.correctWords.map((w) => w.toLowerCase()));
-  const missedSet = new Set(result.missedWords.map((w) => w.toLowerCase()));
+  const correctCounts = buildCountMap(result.correctWords);
+  const missedCounts = buildCountMap(result.missedWords);
   const tokens = tokenizeWords(originalText);
 
   return (
@@ -56,14 +64,18 @@ export function PronunciationResult({ result, originalText, onRetry }: Pronuncia
         <Box {...s.wordList}>
           {tokens.map((word, i) => {
             const lower = word.toLowerCase();
-            if (correctSet.has(lower)) {
+            const correctRemaining = correctCounts.get(lower) ?? 0;
+            if (correctRemaining > 0) {
+              correctCounts.set(lower, correctRemaining - 1);
               return (
                 <Text key={i} {...s.wordCorrect}>
                   {word}
                 </Text>
               );
             }
-            if (missedSet.has(lower)) {
+            const missedRemaining = missedCounts.get(lower) ?? 0;
+            if (missedRemaining > 0) {
+              missedCounts.set(lower, missedRemaining - 1);
               return (
                 <Text key={i} {...s.wordMissed}>
                   {word}

--- a/components/daily-lab/PronunciationResult/index.tsx
+++ b/components/daily-lab/PronunciationResult/index.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Box, Button, Text } from "@chakra-ui/react";
+import { useTranslations } from "next-intl";
+import { LuRotateCcw } from "react-icons/lu";
+import type { AnalyzePronunciationResult } from "@/types/pronunciation";
+import { s } from "./styles";
+
+interface PronunciationResultProps {
+  result: AnalyzePronunciationResult;
+  originalText: string;
+  onRetry: () => void;
+}
+
+function scoreCardBg(score: number): string {
+  const pct = score * 100;
+  if (pct >= 80) return "surface.yellow";
+  if (pct < 60) return "surface.coral";
+  return "card";
+}
+
+function tokenizeWords(text: string): string[] {
+  return text
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.replace(/[^\p{L}\p{N}]+$/u, "").replace(/^[^\p{L}\p{N}]+/u, ""));
+}
+
+export function PronunciationResult({ result, originalText, onRetry }: PronunciationResultProps) {
+  const t = useTranslations("pronunciation");
+  const pct = Math.round(result.score * 100);
+
+  const correctSet = new Set(result.correctWords.map((w) => w.toLowerCase()));
+  const missedSet = new Set(result.missedWords.map((w) => w.toLowerCase()));
+  const tokens = tokenizeWords(originalText);
+
+  return (
+    <Box {...s.wrapper}>
+      <Box {...s.scoreCard} bg={scoreCardBg(result.score)}>
+        <Text {...s.scoreNumber}>{pct}%</Text>
+        <Box {...s.scoreMeta}>
+          <Text {...s.scoreLabel}>{t("result.score")}</Text>
+          <Box {...s.statsRow}>
+            <Text {...s.statCorrect}>
+              ✓ {result.correctWords.length} {t("result.correct")}
+            </Text>
+            <Text {...s.statMissed}>
+              ✗ {result.missedWords.length} {t("result.missed")}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box>
+        <Box {...s.wordList}>
+          {tokens.map((word, i) => {
+            const lower = word.toLowerCase();
+            if (correctSet.has(lower)) {
+              return (
+                <Text key={i} {...s.wordCorrect}>
+                  {word}
+                </Text>
+              );
+            }
+            if (missedSet.has(lower)) {
+              return (
+                <Text key={i} {...s.wordMissed}>
+                  {word}
+                </Text>
+              );
+            }
+            return (
+              <Text key={i} {...s.wordExtra}>
+                {word}
+              </Text>
+            );
+          })}
+        </Box>
+      </Box>
+
+      {result.extraWords.length > 0 && (
+        <Box>
+          <Text {...s.sectionTitle}>{t("result.extra")}</Text>
+          <Box {...s.wordList}>
+            {result.extraWords.map((word, i) => (
+              <Text key={i} {...s.wordExtra}>
+                {word}
+              </Text>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {result.transcription && (
+        <Box {...s.transcriptionBox}>
+          <Text {...s.sectionTitle}>{t("result.transcription")}</Text>
+          <Text {...s.transcriptionText}>{result.transcription}</Text>
+        </Box>
+      )}
+
+      <Button variant="outline" size="sm" onClick={onRetry} {...s.retryButton}>
+        <LuRotateCcw />
+        {t("retry")}
+      </Button>
+    </Box>
+  );
+}

--- a/components/daily-lab/PronunciationResult/styles.ts
+++ b/components/daily-lab/PronunciationResult/styles.ts
@@ -1,0 +1,111 @@
+import type { SystemStyleObject } from "@chakra-ui/react";
+
+export const s = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+  },
+
+  scoreCard: {
+    border: "3px solid black",
+    p: 4,
+    display: "flex",
+    alignItems: "center",
+    gap: 4,
+  },
+
+  scoreNumber: {
+    fontSize: "4xl",
+    fontWeight: "800",
+    lineHeight: 1,
+    flexShrink: 0,
+  },
+
+  scoreMeta: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+  },
+
+  scoreLabel: {
+    fontSize: "xs",
+    fontWeight: "bold",
+    textTransform: "uppercase" as const,
+    letterSpacing: "wider",
+    color: "mutedFg",
+  },
+
+  statsRow: {
+    display: "flex",
+    gap: 4,
+    fontSize: "sm",
+    fontWeight: "600",
+  },
+
+  statCorrect: {
+    color: "green.700",
+  },
+
+  statMissed: {
+    color: "red.700",
+  },
+
+  sectionTitle: {
+    fontSize: "xs",
+    fontWeight: "bold",
+    textTransform: "uppercase" as const,
+    letterSpacing: "wider",
+    color: "mutedFg",
+    mb: 2,
+  },
+
+  wordList: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 1,
+  },
+
+  wordCorrect: {
+    px: 2,
+    py: 0.5,
+    bg: "surface.mint",
+    border: "2px solid black",
+    fontSize: "sm",
+    fontWeight: "600",
+  },
+
+  wordMissed: {
+    px: 2,
+    py: 0.5,
+    bg: "surface.coral",
+    border: "2px solid black",
+    fontSize: "sm",
+    fontWeight: "600",
+  },
+
+  wordExtra: {
+    px: 2,
+    py: 0.5,
+    bg: "card",
+    border: "2px solid black",
+    fontSize: "sm",
+    fontWeight: "500",
+    opacity: 0.7,
+  },
+
+  transcriptionBox: {
+    border: "2px solid black",
+    bg: "card",
+    p: 3,
+  },
+
+  transcriptionText: {
+    fontSize: "sm",
+    fontStyle: "italic",
+  },
+
+  retryButton: {
+    mt: 2,
+  },
+} satisfies Record<string, SystemStyleObject>;

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -271,7 +271,8 @@
       "doneToday": "✓ Done today",
       "notYet": "Not yet",
       "inFocus": "In focus",
-      "todaysFocus": "Today's Focus · Phase {phase} — {theme}"
+      "todaysFocus": "Today's Focus · Phase {phase} — {theme}",
+      "practiceButton": "Practice Pronunciation"
     },
     "journal": {
       "sectionTitle": "Journal",
@@ -686,5 +687,27 @@
       "bestHour": "Best Time"
     },
     "dayOf": "Day {current} / {total}"
+  },
+  "pronunciation": {
+    "practiceButton": "Practice Pronunciation",
+    "modalTitle": "Pronunciation Practice",
+    "referenceText": "Read this text aloud:",
+    "record": "Record",
+    "stop": "Stop",
+    "analyze": "Analyze",
+    "uploading": "Uploading audio...",
+    "analyzing": "Analyzing pronunciation...",
+    "result": {
+      "score": "Score",
+      "correct": "Correct",
+      "missed": "Missed",
+      "extra": "Extra words",
+      "transcription": "What was detected:"
+    },
+    "retry": "Try again",
+    "browserNotSupported": "Your browser does not support audio recording.",
+    "wordCloud": {
+      "title": "Most missed words"
+    }
   }
 }

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -709,7 +709,7 @@
     "browserNotSupported": "Your browser does not support audio recording.",
     "wordCloud": {
       "title": "Most missed words",
-      "itemLabel": "{word}: {count} occurrences"
+      "itemLabel": "{word}: {count, plural, one {# occurrence} other {# occurrences}}"
     }
   }
 }

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -704,10 +704,12 @@
       "extra": "Extra words",
       "transcription": "What was detected:"
     },
+    "audioPreview": "Recorded audio preview",
     "retry": "Try again",
     "browserNotSupported": "Your browser does not support audio recording.",
     "wordCloud": {
-      "title": "Most missed words"
+      "title": "Most missed words",
+      "itemLabel": "{word}: {count} occurrences"
     }
   }
 }

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -271,7 +271,8 @@
       "doneToday": "✓ Hecho hoy",
       "notYet": "Aún no",
       "inFocus": "En foco",
-      "todaysFocus": "Foco de Hoy · Fase {phase} — {theme}"
+      "todaysFocus": "Foco de Hoy · Fase {phase} — {theme}",
+      "practiceButton": "Practicar Pronunciación"
     },
     "journal": {
       "sectionTitle": "Diario",
@@ -686,5 +687,27 @@
       "bestHour": "Mejor Hora"
     },
     "dayOf": "Día {current} / {total}"
+  },
+  "pronunciation": {
+    "practiceButton": "Practicar Pronunciación",
+    "modalTitle": "Práctica de Pronunciación",
+    "referenceText": "Lee este texto en voz alta:",
+    "record": "Grabar",
+    "stop": "Detener",
+    "analyze": "Analizar",
+    "uploading": "Subiendo audio...",
+    "analyzing": "Analizando pronunciación...",
+    "result": {
+      "score": "Puntuación",
+      "correct": "Correctas",
+      "missed": "Perdidas",
+      "extra": "Palabras extra",
+      "transcription": "Lo que se detectó:"
+    },
+    "retry": "Intentar de nuevo",
+    "browserNotSupported": "Tu navegador no admite grabación de audio.",
+    "wordCloud": {
+      "title": "Palabras con más errores"
+    }
   }
 }

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -704,10 +704,12 @@
       "extra": "Palabras extra",
       "transcription": "Lo que se detectó:"
     },
+    "audioPreview": "Vista previa del audio grabado",
     "retry": "Intentar de nuevo",
     "browserNotSupported": "Tu navegador no admite grabación de audio.",
     "wordCloud": {
-      "title": "Palabras con más errores"
+      "title": "Palabras con más errores",
+      "itemLabel": "{word}: {count} ocurrencias"
     }
   }
 }

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -709,7 +709,7 @@
     "browserNotSupported": "Tu navegador no admite grabación de audio.",
     "wordCloud": {
       "title": "Palabras con más errores",
-      "itemLabel": "{word}: {count} ocurrencias"
+      "itemLabel": "{word}: {count, plural, one {# ocurrencia} other {# ocurrencias}}"
     }
   }
 }

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -704,10 +704,12 @@
       "extra": "Palavras extras",
       "transcription": "O que foi detectado:"
     },
+    "audioPreview": "Pré-visualização do áudio gravado",
     "retry": "Tentar novamente",
     "browserNotSupported": "Seu browser não suporta gravação de áudio.",
     "wordCloud": {
-      "title": "Palavras com mais erros"
+      "title": "Palavras com mais erros",
+      "itemLabel": "{word}: {count} ocorrências"
     }
   }
 }

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -271,7 +271,8 @@
       "doneToday": "✓ Feito hoje",
       "notYet": "Ainda não",
       "inFocus": "Em foco",
-      "todaysFocus": "Foco de Hoje · Fase {phase} — {theme}"
+      "todaysFocus": "Foco de Hoje · Fase {phase} — {theme}",
+      "practiceButton": "Praticar Pronúncia"
     },
     "journal": {
       "sectionTitle": "Diário",
@@ -686,5 +687,27 @@
       "bestHour": "Melhor Horário"
     },
     "dayOf": "Dia {current} / {total}"
+  },
+  "pronunciation": {
+    "practiceButton": "Praticar Pronúncia",
+    "modalTitle": "Prática de Pronúncia",
+    "referenceText": "Leia este texto em voz alta:",
+    "record": "Gravar",
+    "stop": "Parar",
+    "analyze": "Analisar",
+    "uploading": "Enviando áudio...",
+    "analyzing": "Analisando pronúncia...",
+    "result": {
+      "score": "Pontuação",
+      "correct": "Corretas",
+      "missed": "Perdidas",
+      "extra": "Palavras extras",
+      "transcription": "O que foi detectado:"
+    },
+    "retry": "Tentar novamente",
+    "browserNotSupported": "Seu browser não suporta gravação de áudio.",
+    "wordCloud": {
+      "title": "Palavras com mais erros"
+    }
   }
 }

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -706,10 +706,10 @@
     },
     "audioPreview": "Pré-visualização do áudio gravado",
     "retry": "Tentar novamente",
-    "browserNotSupported": "Seu browser não suporta gravação de áudio.",
+    "browserNotSupported": "Seu navegador não suporta gravação de áudio.",
     "wordCloud": {
       "title": "Palavras com mais erros",
-      "itemLabel": "{word}: {count} ocorrências"
+      "itemLabel": "{word}: {count, plural, one {# ocorrência} other {# ocorrências}}"
     }
   }
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,7 +14,9 @@ export const API_COLORS = [
   "bg-surface-coral",
   "bg-surface-lavender",
   "bg-surface-yellow",
-];
+] as const;
+
+export type ApiColor = (typeof API_COLORS)[number];
 export const MIN_NAME_LENGTH = 2;
 export const MIN_PASSWORD_LENGTH = 6;
 export const MAX_HABIT_NAME_LENGTH = 80;

--- a/lib/endpoints.ts
+++ b/lib/endpoints.ts
@@ -41,4 +41,9 @@ export const ENDPOINTS = {
   AI: {
     ANALYZE: "/ai/analyze",
   },
+  PRONUNCIATION: {
+    UPLOAD_URL: "/pronunciation/upload-url",
+    ANALYZE: "/pronunciation/analyze",
+    WORD_CLOUD: "/pronunciation/word-cloud",
+  },
 } as const;

--- a/lib/hooks/usePronunciation.ts
+++ b/lib/hooks/usePronunciation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { pronunciationService } from "@/lib/pronunciation.service";
 import { toaster } from "@/components/ui/toaster";
@@ -27,9 +27,11 @@ export function usePronunciation(): UsePronunciationResult {
   const { translateError } = useTranslatedError();
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<AnalyzePronunciationResult | null>(null);
+  const requestIdRef = useRef(0);
 
   const analyze = useCallback(
     async ({ blob, mimeType, habitId, originalText, entryDate }: AnalyzeParams) => {
+      const requestId = ++requestIdRef.current;
       setIsLoading(true);
       try {
         const { signedUrl, publicUrl } = await pronunciationService.getUploadUrl(mimeType);
@@ -40,22 +42,29 @@ export function usePronunciation(): UsePronunciationResult {
           originalText,
           entryDate,
         });
-        setResult(data);
+        if (requestId === requestIdRef.current) {
+          setResult(data);
+        }
       } catch (error) {
-        toaster.create({
-          title: t("title"),
-          description: translateError(error as Error),
-          type: "error",
-          meta: { closable: true },
-        });
+        if (requestId === requestIdRef.current) {
+          toaster.create({
+            title: t("title"),
+            description: translateError(error as Error),
+            type: "error",
+            meta: { closable: true },
+          });
+        }
       } finally {
-        setIsLoading(false);
+        if (requestId === requestIdRef.current) {
+          setIsLoading(false);
+        }
       }
     },
     [t, translateError]
   );
 
   const reset = useCallback(() => {
+    requestIdRef.current += 1;
     setResult(null);
     setIsLoading(false);
   }, []);

--- a/lib/hooks/usePronunciation.ts
+++ b/lib/hooks/usePronunciation.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { pronunciationService } from "@/lib/pronunciation.service";
+import { toaster } from "@/components/ui/toaster";
+import { useTranslatedError } from "./useTranslatedError";
+import type { AnalyzePronunciationResult } from "@/types/pronunciation";
+
+type AnalyzeParams = {
+  blob: Blob;
+  mimeType: string;
+  habitId: string;
+  originalText: string;
+  entryDate: string;
+};
+
+export type UsePronunciationResult = {
+  analyze: (_params: AnalyzeParams) => Promise<void>;
+  isLoading: boolean;
+  result: AnalyzePronunciationResult | null;
+  reset: () => void;
+};
+
+export function usePronunciation(): UsePronunciationResult {
+  const t = useTranslations("errors");
+  const { translateError } = useTranslatedError();
+  const [isLoading, setIsLoading] = useState(false);
+  const [result, setResult] = useState<AnalyzePronunciationResult | null>(null);
+
+  const analyze = useCallback(
+    async ({ blob, mimeType, habitId, originalText, entryDate }: AnalyzeParams) => {
+      setIsLoading(true);
+      try {
+        const { signedUrl, publicUrl } = await pronunciationService.getUploadUrl(mimeType);
+        await pronunciationService.uploadAudio(signedUrl, blob, mimeType);
+        const data = await pronunciationService.analyze({
+          habitId,
+          audioUrl: publicUrl,
+          originalText,
+          entryDate,
+        });
+        setResult(data);
+      } catch (error) {
+        toaster.create({
+          title: t("title"),
+          description: translateError(error as Error),
+          type: "error",
+          meta: { closable: true },
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [t, translateError]
+  );
+
+  const reset = useCallback(() => {
+    setResult(null);
+    setIsLoading(false);
+  }, []);
+
+  return { analyze, isLoading, result, reset };
+}

--- a/lib/hooks/usePronunciationRecorder.ts
+++ b/lib/hooks/usePronunciationRecorder.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+
+export type RecorderState = "idle" | "recording" | "recorded";
+
+export type UsePronunciationRecorderResult = {
+  isSupported: boolean;
+  state: RecorderState;
+  audioBlob: Blob | null;
+  mimeType: string;
+  start: () => void;
+  stop: () => void;
+  reset: () => void;
+};
+
+function detectMimeType(): string {
+  if (typeof MediaRecorder === "undefined") return "audio/webm";
+  return MediaRecorder.isTypeSupported("audio/webm") ? "audio/webm" : "audio/mp4";
+}
+
+export function usePronunciationRecorder(): UsePronunciationRecorderResult {
+  const isSupported = typeof window !== "undefined" && typeof MediaRecorder !== "undefined";
+  const mimeType = isSupported ? detectMimeType() : "audio/webm";
+
+  const [state, setState] = useState<RecorderState>("idle");
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const isResettingRef = useRef(false);
+
+  const start = useCallback(async () => {
+    if (!isSupported) return;
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream, { mimeType });
+
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+
+      recorder.onstop = () => {
+        stream.getTracks().forEach((t) => t.stop());
+        if (isResettingRef.current) return;
+        const blob = new Blob(chunksRef.current, { type: mimeType });
+        setAudioBlob(blob);
+        setState("recorded");
+      };
+
+      mediaRecorderRef.current = recorder;
+      recorder.start();
+      setState("recording");
+    } catch {
+      // microphone permission denied or unavailable — stay idle
+    }
+  }, [isSupported, mimeType]);
+
+  const stop = useCallback(() => {
+    if (mediaRecorderRef.current?.state === "recording") {
+      mediaRecorderRef.current.stop();
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    isResettingRef.current = true;
+    if (mediaRecorderRef.current?.state === "recording") {
+      mediaRecorderRef.current.stop();
+    }
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+    setAudioBlob(null);
+    setState("idle");
+    isResettingRef.current = false;
+  }, []);
+
+  return { isSupported, state, audioBlob, mimeType, start, stop, reset };
+}

--- a/lib/hooks/usePronunciationRecorder.ts
+++ b/lib/hooks/usePronunciationRecorder.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
+import { logger } from "@/lib/logger";
 
 export type RecorderState = "idle" | "recording" | "recorded";
 
@@ -32,6 +33,7 @@ export function usePronunciationRecorder(): UsePronunciationRecorderResult {
 
   const start = useCallback(async () => {
     if (!isSupported) return;
+    isResettingRef.current = false;
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -45,7 +47,10 @@ export function usePronunciationRecorder(): UsePronunciationRecorderResult {
 
       recorder.onstop = () => {
         stream.getTracks().forEach((t) => t.stop());
-        if (isResettingRef.current) return;
+        if (isResettingRef.current) {
+          isResettingRef.current = false;
+          return;
+        }
         const blob = new Blob(chunksRef.current, { type: mimeType });
         setAudioBlob(blob);
         setState("recorded");
@@ -54,8 +59,8 @@ export function usePronunciationRecorder(): UsePronunciationRecorderResult {
       mediaRecorderRef.current = recorder;
       recorder.start();
       setState("recording");
-    } catch {
-      // microphone permission denied or unavailable — stay idle
+    } catch (err) {
+      logger.error("Failed to initialize microphone", err);
     }
   }, [isSupported, mimeType]);
 
@@ -69,12 +74,14 @@ export function usePronunciationRecorder(): UsePronunciationRecorderResult {
     isResettingRef.current = true;
     if (mediaRecorderRef.current?.state === "recording") {
       mediaRecorderRef.current.stop();
+    } else {
+      // onstop won't fire — safe to clear the flag now
+      isResettingRef.current = false;
     }
     mediaRecorderRef.current = null;
     chunksRef.current = [];
     setAudioBlob(null);
     setState("idle");
-    isResettingRef.current = false;
   }, []);
 
   return { isSupported, state, audioBlob, mimeType, start, stop, reset };

--- a/lib/hooks/useWordCloud.ts
+++ b/lib/hooks/useWordCloud.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuthContext } from "@/lib/auth-context";
+import { pronunciationService } from "@/lib/pronunciation.service";
+import type { WordCloudItem } from "@/types/pronunciation";
+
+export function useWordCloud(habitId: string | null) {
+  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+
+  return useQuery<WordCloudItem[], Error>({
+    queryKey: ["word-cloud", habitId],
+    queryFn: () => pronunciationService.getWordCloud(habitId!),
+    enabled: !isAuthLoading && !!accessToken && !!habitId,
+  });
+}

--- a/lib/pronunciation.service.ts
+++ b/lib/pronunciation.service.ts
@@ -1,0 +1,43 @@
+import { api } from "@/lib/api-client";
+import { ENDPOINTS } from "@/lib/endpoints";
+import type { AnalyzePronunciationResult, WordCloudItem } from "@/types/pronunciation";
+
+type AudioUploadUrlResponse = {
+  signedUrl: string;
+  publicUrl: string;
+  path: string;
+};
+
+type AnalyzeInput = {
+  habitId: string;
+  audioUrl: string;
+  originalText: string;
+  entryDate: string;
+};
+
+export const pronunciationService = {
+  async getUploadUrl(contentType: string): Promise<AudioUploadUrlResponse> {
+    return api.post<AudioUploadUrlResponse>(ENDPOINTS.PRONUNCIATION.UPLOAD_URL, { contentType });
+  },
+
+  async uploadAudio(signedUrl: string, blob: Blob, mimeType: string): Promise<void> {
+    const res = await fetch(signedUrl, {
+      method: "PUT",
+      body: blob,
+      headers: { "Content-Type": mimeType },
+    });
+    if (!res.ok) {
+      throw new Error(`Audio upload failed: ${res.status} ${res.statusText}`);
+    }
+  },
+
+  async analyze(input: AnalyzeInput): Promise<AnalyzePronunciationResult> {
+    return api.post<AnalyzePronunciationResult>(ENDPOINTS.PRONUNCIATION.ANALYZE, input);
+  },
+
+  async getWordCloud(habitId: string): Promise<WordCloudItem[]> {
+    return api.get<WordCloudItem[]>(ENDPOINTS.PRONUNCIATION.WORD_CLOUD, {
+      params: { habitId },
+    });
+  },
+};

--- a/tests/unit/components/PronunciationResult.test.tsx
+++ b/tests/unit/components/PronunciationResult.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PronunciationResult } from "@/components/daily-lab/PronunciationResult";
+import { renderWithProviders } from "../../__setup__/render";
+import type { AnalyzePronunciationResult } from "@/types/pronunciation";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const baseResult: AnalyzePronunciationResult = {
+  id: "result-1",
+  userId: "user-1",
+  habitId: "habit-1",
+  entryDate: "2026-03-27",
+  originalText: "hello world",
+  transcription: null,
+  score: 0.9,
+  correctWords: ["hello", "world"],
+  missedWords: [],
+  extraWords: [],
+  audioUrl: null,
+  createdAt: "2026-03-27T00:00:00Z",
+};
+
+function renderResult(overrides: Partial<AnalyzePronunciationResult> = {}, originalText?: string) {
+  const result = { ...baseResult, ...overrides };
+  const onRetry = jest.fn();
+  const rendered = renderWithProviders(
+    <PronunciationResult
+      result={result}
+      originalText={originalText ?? result.originalText}
+      onRetry={onRetry}
+    />
+  );
+  return { ...rendered, onRetry };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("PronunciationResult — score display", () => {
+  it("renders percentage score rounded to nearest integer", () => {
+    renderResult({ score: 0.857 });
+    expect(screen.getByText("86%")).toBeInTheDocument();
+  });
+
+  it("renders 100% for perfect score", () => {
+    renderResult({ score: 1 });
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("renders 0% for zero score", () => {
+    renderResult({ score: 0 });
+    expect(screen.getByText("0%")).toBeInTheDocument();
+  });
+
+  it("renders correct words count", () => {
+    renderResult({ correctWords: ["hello", "world"], score: 1 });
+    expect(screen.getByText(/2/)).toBeInTheDocument();
+  });
+
+  it("renders missed words count", () => {
+    renderResult({ missedWords: ["world"], correctWords: ["hello"], score: 0.5 });
+    expect(screen.getByText(/✗.*1/)).toBeInTheDocument();
+  });
+});
+
+describe("PronunciationResult — word tokenization and highlighting", () => {
+  it("marks correct words with wordCorrect data attribute", () => {
+    renderResult({ correctWords: ["hello", "world"], missedWords: [], score: 1 }, "hello world");
+    const correctWords = screen.getAllByText(/hello|world/);
+    expect(correctWords.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders all tokens from originalText", () => {
+    renderResult({ correctWords: ["the", "quick", "fox"], score: 0.75 }, "the quick fox");
+    expect(screen.getByText("the")).toBeInTheDocument();
+    expect(screen.getByText("quick")).toBeInTheDocument();
+    expect(screen.getByText("fox")).toBeInTheDocument();
+  });
+
+  it("strips trailing punctuation from tokens", () => {
+    renderResult({ correctWords: ["hello", "world"], missedWords: [], score: 1 }, "hello, world.");
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("world")).toBeInTheDocument();
+  });
+
+  it("strips leading punctuation from tokens", () => {
+    renderResult({ correctWords: ["hello"], missedWords: [], score: 1 }, '"hello"');
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("is case-insensitive when matching correct words", () => {
+    renderResult({ correctWords: ["Hello"], missedWords: [], score: 1 }, "hello");
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("is case-insensitive when matching missed words", () => {
+    renderResult({ correctWords: [], missedWords: ["WORLD"], score: 0 }, "world");
+    expect(screen.getByText("world")).toBeInTheDocument();
+  });
+
+  it("handles multiple spaces between words by collapsing them", () => {
+    renderResult({ correctWords: ["hello", "world"], score: 1 }, "hello   world");
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("world")).toBeInTheDocument();
+  });
+
+  it("handles leading and trailing whitespace in originalText", () => {
+    renderResult({ correctWords: ["hello"], score: 1 }, "  hello  ");
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("renders words not in correct or missed sets as extra (neutral)", () => {
+    renderResult({ correctWords: ["hello"], missedWords: [], score: 0.5 }, "hello unknown");
+    expect(screen.getByText("unknown")).toBeInTheDocument();
+  });
+});
+
+describe("PronunciationResult — extra words section", () => {
+  it("does not render extra words section when extraWords is empty", () => {
+    renderResult({ extraWords: [] });
+    expect(screen.queryByText("result.extra")).not.toBeInTheDocument();
+  });
+
+  it("renders extra words section when extraWords has items", () => {
+    renderResult({ extraWords: ["surprise"] });
+    expect(screen.getByText("result.extra")).toBeInTheDocument();
+    expect(screen.getByText("surprise")).toBeInTheDocument();
+  });
+
+  it("renders all extra words", () => {
+    renderResult({ extraWords: ["foo", "bar", "baz"] });
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    expect(screen.getByText("bar")).toBeInTheDocument();
+    expect(screen.getByText("baz")).toBeInTheDocument();
+  });
+});
+
+describe("PronunciationResult — transcription section", () => {
+  it("does not render transcription section when transcription is null", () => {
+    renderResult({ transcription: null });
+    expect(screen.queryByText("result.transcription")).not.toBeInTheDocument();
+  });
+
+  it("renders transcription section when transcription is provided", () => {
+    renderResult({ transcription: "hello world" });
+    expect(screen.getByText("result.transcription")).toBeInTheDocument();
+    expect(screen.getByText("hello world")).toBeInTheDocument();
+  });
+});
+
+describe("PronunciationResult — retry button", () => {
+  it("renders the retry button", () => {
+    renderResult();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("calls onRetry when retry button is clicked", async () => {
+    const { onRetry } = renderResult();
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/WordCloudErrors.test.tsx
+++ b/tests/unit/components/WordCloudErrors.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { WordCloudErrors } from "@/components/Analytics/WordCloudErrors";
+import { renderWithProviders } from "../../__setup__/render";
+import type { WordCloudItem } from "@/types/pronunciation";
+
+const mockUseWordCloud = jest.fn();
+
+jest.mock("@/lib/hooks/useWordCloud", () => ({
+  useWordCloud: (...args: unknown[]) => mockUseWordCloud(...args),
+}));
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuthContext: () => ({ isLoading: false, accessToken: "token" }),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("WordCloudErrors — empty state", () => {
+  it("renders null when data is an empty array", () => {
+    mockUseWordCloud.mockReturnValue({ data: [] });
+
+    const { container } = renderWithProviders(
+      <WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null when data is undefined (query not yet resolved)", () => {
+    mockUseWordCloud.mockReturnValue({ data: undefined });
+
+    const { container } = renderWithProviders(
+      <WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("WordCloudErrors — renders words", () => {
+  const items: WordCloudItem[] = [
+    { word: "pronunciation", frequency: 10 },
+    { word: "difficult", frequency: 5 },
+    { word: "challenge", frequency: 1 },
+  ];
+
+  it("renders all words from data", () => {
+    mockUseWordCloud.mockReturnValue({ data: items });
+
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+
+    expect(screen.getByText("pronunciation")).toBeInTheDocument();
+    expect(screen.getByText("difficult")).toBeInTheDocument();
+    expect(screen.getByText("challenge")).toBeInTheDocument();
+  });
+
+  it("renders the section title", () => {
+    mockUseWordCloud.mockReturnValue({ data: items });
+
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+
+    expect(screen.getByText("wordCloud.title")).toBeInTheDocument();
+  });
+
+  it("passes habitId to useWordCloud", () => {
+    mockUseWordCloud.mockReturnValue({ data: items });
+
+    renderWithProviders(<WordCloudErrors habitId="habit-42" habitColor="bg-teal-400" />);
+
+    expect(mockUseWordCloud).toHaveBeenCalledWith("habit-42");
+  });
+});
+
+describe("WordCloudErrors — font size scaling", () => {
+  it("renders a single word without crashing (min === max edge case)", () => {
+    mockUseWordCloud.mockReturnValue({ data: [{ word: "only", frequency: 7 }] });
+
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+
+    expect(screen.getByText("only")).toBeInTheDocument();
+  });
+
+  it("highest-frequency word receives a larger font size than the lowest", () => {
+    const words: WordCloudItem[] = [
+      { word: "common", frequency: 20 },
+      { word: "rare", frequency: 1 },
+    ];
+    mockUseWordCloud.mockReturnValue({ data: words });
+
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+
+    const commonEl = screen.getByText("common");
+    const rareEl = screen.getByText("rare");
+
+    const commonSize = parseFloat(commonEl.getAttribute("data-fontsize") ?? "0");
+    const rareSize = parseFloat(rareEl.getAttribute("data-fontsize") ?? "0");
+
+    expect(commonSize).toBeGreaterThan(rareSize);
+  });
+});

--- a/tests/unit/components/WordCloudErrors.test.tsx
+++ b/tests/unit/components/WordCloudErrors.test.tsx
@@ -84,7 +84,9 @@ describe("WordCloudErrors — font size scaling", () => {
 
     renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
 
-    expect(screen.getByText("only")).toBeInTheDocument();
+    const onlySize = parseFloat(screen.getByText("only").getAttribute("data-fontsize") ?? "0");
+    expect(onlySize).toBeGreaterThanOrEqual(0.8);
+    expect(onlySize).toBeLessThanOrEqual(2);
   });
 
   it("highest-frequency word receives a larger font size than the lowest", () => {
@@ -102,6 +104,7 @@ describe("WordCloudErrors — font size scaling", () => {
     const commonSize = parseFloat(commonEl.getAttribute("data-fontsize") ?? "0");
     const rareSize = parseFloat(rareEl.getAttribute("data-fontsize") ?? "0");
 
-    expect(commonSize).toBeGreaterThan(rareSize);
+    expect(commonSize).toBeCloseTo(2, 3);
+    expect(rareSize).toBeCloseTo(0.8, 3);
   });
 });

--- a/tests/unit/components/WordCloudErrors.test.tsx
+++ b/tests/unit/components/WordCloudErrors.test.tsx
@@ -22,6 +22,19 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+describe("WordCloudErrors — loading state", () => {
+  it("renders Skeleton when isLoading is true", () => {
+    mockUseWordCloud.mockReturnValue({ data: [], isLoading: true });
+
+    const { container } = renderWithProviders(
+      <WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />
+    );
+
+    // Skeleton renders something (not null) while loading
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
 describe("WordCloudErrors — empty state", () => {
   it("renders null when data is an empty array", () => {
     mockUseWordCloud.mockReturnValue({ data: [] });

--- a/tests/unit/components/WordCloudErrors.test.tsx
+++ b/tests/unit/components/WordCloudErrors.test.tsx
@@ -26,12 +26,9 @@ describe("WordCloudErrors — loading state", () => {
   it("renders Skeleton when isLoading is true", () => {
     mockUseWordCloud.mockReturnValue({ data: [], isLoading: true });
 
-    const { container } = renderWithProviders(
-      <WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />
-    );
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />);
 
-    // Skeleton renders something (not null) while loading
-    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByTestId("word-cloud-skeleton")).toBeInTheDocument();
   });
 });
 
@@ -100,9 +97,9 @@ describe("WordCloudErrors — duplicate words", () => {
       ],
     });
 
-    expect(() =>
-      renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />)
-    ).not.toThrow();
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />);
+
+    expect(screen.getAllByText("the")).toHaveLength(2);
   });
 });
 

--- a/tests/unit/components/WordCloudErrors.test.tsx
+++ b/tests/unit/components/WordCloudErrors.test.tsx
@@ -27,7 +27,7 @@ describe("WordCloudErrors — empty state", () => {
     mockUseWordCloud.mockReturnValue({ data: [] });
 
     const { container } = renderWithProviders(
-      <WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />
+      <WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />
     );
 
     expect(container.firstChild).toBeNull();
@@ -37,7 +37,7 @@ describe("WordCloudErrors — empty state", () => {
     mockUseWordCloud.mockReturnValue({ data: undefined });
 
     const { container } = renderWithProviders(
-      <WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />
+      <WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />
     );
 
     expect(container.firstChild).toBeNull();
@@ -54,7 +54,7 @@ describe("WordCloudErrors — renders words", () => {
   it("renders all words from data", () => {
     mockUseWordCloud.mockReturnValue({ data: items });
 
-    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />);
 
     expect(screen.getByText("pronunciation")).toBeInTheDocument();
     expect(screen.getByText("difficult")).toBeInTheDocument();
@@ -64,7 +64,7 @@ describe("WordCloudErrors — renders words", () => {
   it("renders the section title", () => {
     mockUseWordCloud.mockReturnValue({ data: items });
 
-    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />);
 
     expect(screen.getByText("wordCloud.title")).toBeInTheDocument();
   });
@@ -72,9 +72,24 @@ describe("WordCloudErrors — renders words", () => {
   it("passes habitId to useWordCloud", () => {
     mockUseWordCloud.mockReturnValue({ data: items });
 
-    renderWithProviders(<WordCloudErrors habitId="habit-42" habitColor="bg-teal-400" />);
+    renderWithProviders(<WordCloudErrors habitId="habit-42" habitColor="bg-surface-mint" />);
 
     expect(mockUseWordCloud).toHaveBeenCalledWith("habit-42");
+  });
+});
+
+describe("WordCloudErrors — duplicate words", () => {
+  it("renders duplicate words without crashing (uses index-based key)", () => {
+    mockUseWordCloud.mockReturnValue({
+      data: [
+        { word: "the", frequency: 10 },
+        { word: "the", frequency: 8 },
+      ],
+    });
+
+    expect(() =>
+      renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />)
+    ).not.toThrow();
   });
 });
 
@@ -82,7 +97,7 @@ describe("WordCloudErrors — font size scaling", () => {
   it("renders a single word without crashing (min === max edge case)", () => {
     mockUseWordCloud.mockReturnValue({ data: [{ word: "only", frequency: 7 }] });
 
-    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />);
 
     const onlySize = parseFloat(screen.getByText("only").getAttribute("data-fontsize") ?? "0");
     expect(onlySize).toBeGreaterThanOrEqual(0.8);
@@ -96,7 +111,7 @@ describe("WordCloudErrors — font size scaling", () => {
     ];
     mockUseWordCloud.mockReturnValue({ data: words });
 
-    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-teal-400" />);
+    renderWithProviders(<WordCloudErrors habitId="habit-1" habitColor="bg-surface-mint" />);
 
     const commonEl = screen.getByText("common");
     const rareEl = screen.getByText("rare");

--- a/tests/unit/lib/use-pronunciation-recorder.test.ts
+++ b/tests/unit/lib/use-pronunciation-recorder.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, act } from "@testing-library/react";
+import { usePronunciationRecorder } from "@/lib/hooks/usePronunciationRecorder";
+
+const originalMediaRecorder = (global as Record<string, unknown>).MediaRecorder;
+
+afterEach(() => {
+  if (originalMediaRecorder === undefined) {
+    delete (global as Record<string, unknown>).MediaRecorder;
+  } else {
+    (global as Record<string, unknown>).MediaRecorder = originalMediaRecorder;
+  }
+  jest.clearAllMocks();
+});
+
+describe("usePronunciationRecorder — isSupported", () => {
+  it("returns isSupported=false when MediaRecorder is not defined", () => {
+    delete (global as Record<string, unknown>).MediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it("returns isSupported=true when MediaRecorder is available", () => {
+    const mockMediaRecorder = Object.assign(jest.fn(), {
+      isTypeSupported: jest.fn().mockReturnValue(true),
+    });
+    (global as Record<string, unknown>).MediaRecorder = mockMediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    expect(result.current.isSupported).toBe(true);
+  });
+});
+
+describe("usePronunciationRecorder — mimeType detection", () => {
+  it("defaults to audio/webm when MediaRecorder is not defined", () => {
+    delete (global as Record<string, unknown>).MediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    expect(result.current.mimeType).toBe("audio/webm");
+  });
+
+  it("uses audio/webm when MediaRecorder supports it", () => {
+    const mockMediaRecorder = Object.assign(jest.fn(), {
+      isTypeSupported: jest.fn((mime: string) => mime === "audio/webm"),
+    });
+    (global as Record<string, unknown>).MediaRecorder = mockMediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    expect(result.current.mimeType).toBe("audio/webm");
+  });
+
+  it("falls back to audio/mp4 when audio/webm is not supported", () => {
+    const mockMediaRecorder = Object.assign(jest.fn(), {
+      isTypeSupported: jest.fn().mockReturnValue(false),
+    });
+    (global as Record<string, unknown>).MediaRecorder = mockMediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    expect(result.current.mimeType).toBe("audio/mp4");
+  });
+});
+
+describe("usePronunciationRecorder — initial state", () => {
+  it("starts in idle state", () => {
+    delete (global as Record<string, unknown>).MediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("starts with audioBlob as null", () => {
+    delete (global as Record<string, unknown>).MediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    expect(result.current.audioBlob).toBeNull();
+  });
+});
+
+describe("usePronunciationRecorder — start when not supported", () => {
+  it("does not throw and stays idle when start is called without MediaRecorder support", async () => {
+    delete (global as Record<string, unknown>).MediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    await act(async () => {
+      result.current.start();
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(result.current.audioBlob).toBeNull();
+  });
+});
+
+describe("usePronunciationRecorder — reset", () => {
+  it("resets state to idle and clears audioBlob", async () => {
+    delete (global as Record<string, unknown>).MediaRecorder;
+
+    const { result } = renderHook(() => usePronunciationRecorder());
+
+    await act(async () => {
+      result.current.reset();
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(result.current.audioBlob).toBeNull();
+  });
+});

--- a/types/pronunciation.ts
+++ b/types/pronunciation.ts
@@ -1,0 +1,19 @@
+export type WordCloudItem = {
+  word: string;
+  frequency: number;
+};
+
+export type AnalyzePronunciationResult = {
+  id: string;
+  userId: string;
+  habitId: string;
+  entryDate: string;
+  originalText: string;
+  transcription: string | null;
+  score: number;
+  missedWords: string[];
+  correctWords: string[];
+  extraWords: string[];
+  audioUrl: string | null;
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary

- Adds pronunciation practice flow to language habits in Daily Lab: record audio → upload to Supabase → analyze via backend → show score + word highlighting
- Adds word cloud to Analytics page showing most-missed words per habit
- 37 unit tests covering recorder hook, result tokenization/highlighting, and word cloud scaling

## Changes

### New files
- `types/pronunciation.ts` — `AnalyzePronunciationResult`, `WordCloudItem` types
- `lib/pronunciation.service.ts` — `getUploadUrl`, `uploadAudio` (native PUT), `analyze`, `getWordCloud`
- `lib/hooks/usePronunciationRecorder.ts` — MediaRecorder wrapper with webm/mp4 detection, race-condition-safe reset, memory-leak-safe `createObjectURL`
- `lib/hooks/usePronunciation.ts` — upload + analyze orchestration hook
- `lib/hooks/useWordCloud.ts` — query hook for analytics word cloud
- `components/daily-lab/PronunciationModal/` — Dialog with states: idle → recording → recorded → loading → result
- `components/daily-lab/PronunciationResult/` — score card + word highlighting (correct/missed/extra) + transcription
- `components/Analytics/WordCloudErrors/` — word cloud with font size scaled by miss frequency

### Modified files
- `lib/endpoints.ts` — added `PRONUNCIATION` endpoints
- `components/daily-lab/HabitChecklist/index.tsx` — mic button inside `planCard` for `SkillBuildingPhase` habits
- `app/[locale]/(app)/daily-lab/page.tsx` — passes `today` prop to `HabitChecklist`
- `app/[locale]/(app)/analytics/page.tsx` — `WordCloudErrors` below `ScoreTimeline` for language habits
- `i18n/messages/pt-BR.json`, `en-US.json`, `es-ES.json` — `pronunciation` namespace

## Test plan

- [ ] Click "Praticar Pronúncia" button on a language habit with `plan_status === "ready"`
- [ ] Record audio, stop, preview with `<audio>` player
- [ ] Click "Analisar" — spinner appears, result renders inline with score + colored words
- [ ] "Tentar novamente" resets modal to idle
- [ ] Browser without `MediaRecorder` shows fallback message
- [ ] Analytics page: word cloud visible for language habits with prior sessions, hidden if no data
- [ ] i18n: test pt-BR, en-US, es-ES
- [ ] Unit tests: `yarn jest tests/unit/components/PronunciationResult.test.tsx tests/unit/components/WordCloudErrors.test.tsx tests/unit/lib/use-pronunciation-recorder.test.ts` — 37/37 pass

## Related

Backend prerequisite: pedrolucazx/imm-api#134
Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Novas Funcionalidades**
  * Fluxo de prática de pronúncia: botão "Praticar Pronúncia", modal de gravação/análise, retry e player.
  * Visualizador de nuvem de palavras nos relatórios (word cloud).
  * Integração de gravação no navegador com start/stop/reset e upload/analise via API.
  * Exibição de resultado: pontuação, palavras corretas/erradas/extra e transcrição.  
* **i18n**
  * Novas strings de pronúncia em PT/EN/ES e botão "Praticar Pronúncia".
* **Tests**
  * Novos testes unitários para componentes e hooks de pronúncia e nuvem de palavras.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->