### PR TITLE
feat(onboarding): interactive onboarding tour for new users (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@
 
 **Analytics** — heatmap de streak, taxas de conclusão e histórico de progresso por hábito.
 
+**Onboarding Tour** — tour interativo de 6 steps (Welcome → Habits → Daily Lab → Journal → Analytics → Finish) exibido automaticamente para novos usuários na primeira sessão. Pode ser reiniciado a qualquer momento nas Configurações.
+
 ---
 
 ## Arquitetura
@@ -67,7 +69,9 @@ imm-web (Next.js App Router)
 ├── components/ui/                 # Design system customizado sobre Chakra UI
 ├── lib/                           # API client, hooks, serviços
 │   ├── hooks/useAuth.ts           # Autenticação e gerenciamento de tokens
+│   ├── hooks/useOnboarding.ts     # Estado e controle do tour de onboarding
 │   ├── auth.service.ts            # Chamadas de API de autenticação
+│   ├── onboarding.service.ts      # Persistência do estado do tour (API/localStorage)
 │   └── endpoints.ts               # Mapa tipado de endpoints da API
 └── providers/                     # Provedores de contexto (QueryClient, Chakra, etc.)
 ```
@@ -88,6 +92,7 @@ imm-web (Next.js App Router)
 | HTTP / Estado           | TanStack Query v5 + Axios                |
 | Formulários             | React Hook Form v7                       |
 | Internacionalização     | next-intl v4                             |
+| Tour / Onboarding       | `@zag-js/tour` v1 + `@zag-js/react`      |
 | Testes Unit/Integration | Jest + React Testing Library + MSW       |
 | Testes E2E              | Playwright (Chromium)                    |
 | Deployment              | Vercel                                   |
@@ -105,19 +110,27 @@ imm-web/
 │       │   └── register/          # Página de registro
 │       └── (landing)/             # Página de landing pública
 ├── components/
+│   ├── onboarding/                # Tour interativo de onboarding
+│   │   ├── OnboardingTour.tsx     # Orquestrador do tour (máquina Zag)
+│   │   ├── OnboardingWrapper.tsx  # Provider que inicializa o tour para novos usuários
+│   │   ├── TourBackdrop.tsx       # Overlay de fundo durante o tour
+│   │   ├── TourStep.tsx           # Popover de cada step do tour
+│   │   └── TourStep.styles.ts     # Estilos do TourStep
 │   └── ui/                        # Componentes Chakra UI customizados e wrapped
 │       ├── Button.tsx
 │       ├── Input.tsx
 │       └── ...
 ├── lib/
 │   ├── hooks/
-│   │   └── useAuth.ts             # Hook de autenticação
+│   │   ├── useAuth.ts             # Hook de autenticação
+│   │   └── useOnboarding.ts       # Hook de estado e controle do tour
 │   ├── auth.service.ts            # Camada de serviço de auth API
 │   └── endpoints.ts               # Constantes de endpoints API tipadas
 ├── providers/                     # Provedores de contexto React (QueryClient, Chakra, etc.)
 ├── i18n/                          # Configuração next-intl e request handler
 ├── styles/                        # CSS global
 ├── types/                         # Definições de tipos TypeScript compartilhadas
+│   └── onboarding.ts              # Tipos do tour (steps, estado, config)
 ├── middleware.ts                  # Middleware de roteamento de locale
 ├── tests/
 │   ├── __setup__/                 # Setup global de Jest & MSW

--- a/app/[locale]/(app)/settings/page.tsx
+++ b/app/[locale]/(app)/settings/page.tsx
@@ -254,7 +254,7 @@ export default function SettingsPage(): React.JSX.Element {
               onClick={async () => {
                 try {
                   await restartTour();
-                  router.push(ROUTES.APP_DAILY_LAB);
+                  router.replace(ROUTES.APP_DAILY_LAB);
                 } catch {
                   toaster.create({
                     type: "error",

--- a/components/onboarding/OnboardingTour.tsx
+++ b/components/onboarding/OnboardingTour.tsx
@@ -32,7 +32,6 @@ import { logger } from "@/lib/logger";
 import { TourBackdrop } from "./TourBackdrop";
 import { TourStep } from "./TourStep";
 
-const TOTAL_STEPS = 6;
 const TOUR_CARD_WIDTH = 380;
 const TOUR_VIEWPORT_PADDING = 24;
 
@@ -218,11 +217,13 @@ export function OnboardingTour() {
 
   const completeTourRef = useRef(completeTour);
   const skipTourRef = useRef(skipTour);
+  const stepsRef = useRef(steps);
 
   useEffect(() => {
     completeTourRef.current = completeTour;
     skipTourRef.current = skipTour;
-  }, [completeTour, skipTour]);
+    stepsRef.current = steps;
+  }, [completeTour, skipTour, steps]);
 
   const machineId = useId();
   const service = useMachine(tourMachine, {
@@ -231,7 +232,10 @@ export function OnboardingTour() {
     closeOnInteractOutside: false,
     closeOnEscape: false,
     onStatusChange({ status, stepIndex }: StatusChangeDetails) {
-      if (status === "completed" || (status === "dismissed" && stepIndex === TOTAL_STEPS - 1)) {
+      if (
+        status === "completed" ||
+        (status === "dismissed" && stepIndex === stepsRef.current.length - 1)
+      ) {
         completeTourRef
           .current()
           .catch((err: unknown) => logger.error({ err }, "onboarding: completeTour failed"));

--- a/components/onboarding/TourStep.tsx
+++ b/components/onboarding/TourStep.tsx
@@ -10,10 +10,10 @@ interface TourStepProps {
 }
 
 const variantBg: Record<string, string> = {
-  primary: "var(--chakra-colors-brand-yellow, #FFD700)",
-  secondary: "var(--chakra-colors-brand-mint, #00D26A)",
-  accent: "var(--chakra-colors-brand-coral, #FF6B6B)",
-  muted: "var(--chakra-colors-card, #fff)",
+  primary: "primary",
+  secondary: "secondary",
+  accent: "accent",
+  muted: "muted",
 };
 
 function TourCard({ api }: TourStepProps) {

--- a/components/onboarding/TourStep.tsx
+++ b/components/onboarding/TourStep.tsx
@@ -9,13 +9,6 @@ interface TourStepProps {
   api: Api;
 }
 
-const variantBg: Record<string, string> = {
-  primary: "primary",
-  secondary: "secondary",
-  accent: "accent",
-  muted: "muted",
-};
-
 function TourCard({ api }: TourStepProps) {
   const totalSteps = api.totalSteps;
   const t = useTranslations("onboarding");
@@ -51,14 +44,13 @@ function TourCard({ api }: TourStepProps) {
         {api.step?.actions?.map((action) => {
           const triggerProps = api.getActionTriggerProps({ action });
           const variant = (action.attrs?.variant as string) ?? "muted";
-          const bg = variantBg[variant] ?? variantBg.muted;
 
           return (
             <chakra.button
               key={action.label}
               {...triggerProps}
               {...s.actionBtn}
-              bg={bg}
+              bg={variant}
               color="black"
             >
               {action.label}

--- a/i18n/messages/en-US.json
+++ b/i18n/messages/en-US.json
@@ -749,7 +749,6 @@
     "step5Desc": "You have seen the main features. Now it is time to put them into practice and build your routine.",
     "btnNext": "Next",
     "btnBack": "Back",
-    "btnSkip": "Skip",
     "btnStart": "Get started",
     "btnClose": "Close",
     "progress": "{current} of {total}"

--- a/i18n/messages/es-ES.json
+++ b/i18n/messages/es-ES.json
@@ -749,7 +749,6 @@
     "step5Desc": "Ya conoces las principales funcionalidades. Ahora es el momento de ponerlas en práctica y crear tu rutina.",
     "btnNext": "Siguiente",
     "btnBack": "Atrás",
-    "btnSkip": "Saltar",
     "btnStart": "Empezar",
     "btnClose": "Cerrar",
     "progress": "{current} de {total}"

--- a/i18n/messages/pt-BR.json
+++ b/i18n/messages/pt-BR.json
@@ -749,7 +749,6 @@
     "step5Desc": "Você conheceu as principais funcionalidades. Agora é hora de colocar em prática e criar sua rotina.",
     "btnNext": "Próximo",
     "btnBack": "Voltar",
-    "btnSkip": "Pular",
     "btnStart": "Começar",
     "btnClose": "Fechar",
     "progress": "{current} de {total}"

--- a/tests/__setup__/msw/handlers.ts
+++ b/tests/__setup__/msw/handlers.ts
@@ -107,10 +107,26 @@ export const handlers = [
   }),
 
   http.get(`${API_URL}/users/me/onboarding`, () => {
-    return HttpResponse.json({ completed: false, skipped: false, currentStep: 0 });
+    return HttpResponse.json({
+      completed: false,
+      skipped: false,
+      currentStep: 0,
+      completedAt: null,
+    });
   }),
 
-  http.put(`${API_URL}/users/me/onboarding`, () => {
-    return HttpResponse.json({ completed: false, skipped: false, currentStep: 0 });
+  http.put(`${API_URL}/users/me/onboarding`, async ({ request }) => {
+    const body = (await request.json()) as {
+      completed?: boolean;
+      skipped?: boolean;
+      currentStep?: number;
+    };
+    return HttpResponse.json({
+      completed: false,
+      skipped: false,
+      currentStep: 0,
+      completedAt: null,
+      ...body,
+    });
   }),
 ];

--- a/tests/__setup__/msw/handlers.ts
+++ b/tests/__setup__/msw/handlers.ts
@@ -122,11 +122,10 @@ export const handlers = [
       currentStep?: number;
     };
     return HttpResponse.json({
-      completed: false,
-      skipped: false,
-      currentStep: 0,
-      completedAt: null,
-      ...body,
+      completed: body.completed ?? false,
+      skipped: body.skipped ?? false,
+      currentStep: body.currentStep ?? 0,
+      completedAt: body.completed ? new Date().toISOString() : null,
     });
   }),
 ];

--- a/tests/__setup__/msw/handlers.ts
+++ b/tests/__setup__/msw/handlers.ts
@@ -105,4 +105,12 @@ export const handlers = [
 
     return HttpResponse.json({ message: "Verification email sent" });
   }),
+
+  http.get(`${API_URL}/users/me/onboarding`, () => {
+    return HttpResponse.json({ completed: false, skipped: false, currentStep: 0 });
+  }),
+
+  http.put(`${API_URL}/users/me/onboarding`, () => {
+    return HttpResponse.json({ completed: false, skipped: false, currentStep: 0 });
+  }),
 ];

--- a/tests/unit/lib/onboarding.service.test.ts
+++ b/tests/unit/lib/onboarding.service.test.ts
@@ -1,0 +1,70 @@
+import { onboardingService } from "@/lib/onboarding.service";
+import { api } from "@/lib/api-client";
+import { ENDPOINTS } from "@/lib/endpoints";
+import type { OnboardingSession } from "@/types/onboarding";
+
+jest.mock("@/lib/api-client", () => ({
+  api: {
+    get: jest.fn(),
+    put: jest.fn(),
+  },
+}));
+
+const mockApi = api as jest.Mocked<typeof api>;
+
+const mockSession: OnboardingSession = {
+  completed: false,
+  skipped: false,
+  currentStep: 0,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("onboardingService", () => {
+  describe("getStatus", () => {
+    it("calls GET on the onboarding endpoint", async () => {
+      mockApi.get.mockResolvedValue(mockSession);
+
+      const result = await onboardingService.getStatus();
+
+      expect(mockApi.get).toHaveBeenCalledWith(ENDPOINTS.USER.ONBOARDING);
+      expect(result).toEqual(mockSession);
+    });
+
+    it("propagates API errors", async () => {
+      mockApi.get.mockRejectedValue(new Error("Network error"));
+
+      await expect(onboardingService.getStatus()).rejects.toThrow("Network error");
+    });
+  });
+
+  describe("update", () => {
+    it("calls PUT with completed payload", async () => {
+      const updated: OnboardingSession = { ...mockSession, completed: true };
+      mockApi.put.mockResolvedValue(updated);
+
+      const result = await onboardingService.update({ completed: true });
+
+      expect(mockApi.put).toHaveBeenCalledWith(ENDPOINTS.USER.ONBOARDING, { completed: true });
+      expect(result).toEqual(updated);
+    });
+
+    it("calls PUT with skipped payload", async () => {
+      const updated: OnboardingSession = { ...mockSession, skipped: true };
+      mockApi.put.mockResolvedValue(updated);
+
+      const result = await onboardingService.update({ skipped: true });
+
+      expect(mockApi.put).toHaveBeenCalledWith(ENDPOINTS.USER.ONBOARDING, { skipped: true });
+      expect(result).toEqual(updated);
+    });
+
+    it("propagates API errors", async () => {
+      mockApi.put.mockRejectedValue(new Error("Unauthorized"));
+
+      await expect(onboardingService.update({ completed: true })).rejects.toThrow("Unauthorized");
+    });
+  });
+});

--- a/tests/unit/lib/onboarding.service.test.ts
+++ b/tests/unit/lib/onboarding.service.test.ts
@@ -16,6 +16,7 @@ const mockSession: OnboardingSession = {
   completed: false,
   skipped: false,
   currentStep: 0,
+  completedAt: null,
 };
 
 beforeEach(() => {

--- a/tests/unit/lib/onboarding.service.test.ts
+++ b/tests/unit/lib/onboarding.service.test.ts
@@ -62,6 +62,16 @@ describe("onboardingService", () => {
       expect(result).toEqual(updated);
     });
 
+    it("calls PUT with currentStep payload", async () => {
+      const updated: OnboardingSession = { ...mockSession, currentStep: 3 };
+      mockApi.put.mockResolvedValue(updated);
+
+      const result = await onboardingService.update({ currentStep: 3 });
+
+      expect(mockApi.put).toHaveBeenCalledWith(ENDPOINTS.USER.ONBOARDING, { currentStep: 3 });
+      expect(result).toEqual(updated);
+    });
+
     it("propagates API errors", async () => {
       mockApi.put.mockRejectedValue(new Error("Unauthorized"));
 


### PR DESCRIPTION
## Summary

- Tour interativo de 6 steps disparado automaticamente para novos usuários após login
- Fluxo: Welcome → Habits → Daily Lab → Journal → Analytics → Finish
- Navegação automática para a página correta em cada step (habits, daily-lab, analytics)
- Tour sobrevive a abertura/fechamento de modais (closeOnInteractOutside/Escape desativados, trapFocus no-op)
- Opção de reiniciar disponível nas Configurações
- Server como fonte da verdade; localStorage como write-cache por userId

## Componentes novos

- `components/onboarding/OnboardingTour.tsx` — orquestrador com @zag-js/tour e navegação por página
- `components/onboarding/TourStep.tsx` — card Neo Brutalism com indicador de progresso (deriva totalSteps de api.totalSteps)
- `components/onboarding/TourBackdrop.tsx` — backdrop e spotlight overlay
- `components/onboarding/OnboardingWrapper.tsx` — client boundary no app layout

## Hook & service

- `lib/hooks/useOnboarding.ts` — TanStack Query; queryKey por userId; enabled somente quando `Boolean(user?.id)`; LS como write-cache
- `lib/onboarding.service.ts` — chamadas REST para `GET/PUT /api/users/me/onboarding`

## Arquivos modificados

- `app/[locale]/(app)/layout.tsx` — monta OnboardingWrapper
- `app/[locale]/(app)/settings/page.tsx` — card de reiniciar tour (usa router.replace)
- `app/[locale]/(app)/habits/page.tsx` — `data-tour="habits-section"`
- `app/[locale]/(app)/daily-lab/page.tsx` — `data-tour="journal-section"` wrapper
- `app/[locale]/(app)/analytics/page.tsx` — `data-tour="analytics-section"`
- `components/Sidebar/index.tsx` — `data-tour` em habits/analytics
- i18n (pt-BR, en-US, es-ES) — namespace `onboarding` com todas as chaves
- `tests/__setup__/msw/handlers.ts` — handlers MSW para `/users/me/onboarding`

## Testes

- [x] 16 unit tests para `useOnboarding` (shouldShowTour, localStorage per userId, complete/skip/restart, error paths, user-switch regression)
- [x] 5 unit tests para `onboarding.service`
- [x] Suite completa: 243/243 passando

## Test plan manual

- [ ] Nova conta dispara o tour no primeiro login
- [ ] Tour navega para habits, daily-lab, analytics automaticamente
- [ ] Abrir modal de criar hábito durante o tour não o fecha
- [ ] Reiniciar nas Configurações re-dispara o tour
- [ ] Completar/pular o tour impede que ele apareça novamente

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Tour interativo de onboarding multi-etapas para novos usuários, executado automaticamente na primeira sessão.
  * Opção para reiniciar o tour nas Configurações.

* **Melhorias**
  * Ajustado comportamento de navegação após reiniciar o tour (histórico otimizado).
  * Lógica do tour agora acompanha dinamicamente o número de passos.

* **Correções**
  * Removido o botão "Pular" do tour de onboarding.

* **Documentação**
  * Atualizada documentação e arquitetura para incluir o sistema de onboarding.

* **Testes**
  * Adicionada cobertura de testes para o serviço de onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->