### PR TITLE
fix(auth): stabilize bootstrap after page reload

### DIFF
--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -54,6 +54,7 @@ export function CookieBanner() {
     setIsPrivacyModalOpen(false);
   };
 
+  if (!isAuthReady) return null;
   if (!isVisible && !isPrivacyModalOpen) return null;
 
   return (

--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -4,15 +4,18 @@ import { useState, useEffect } from "react";
 import { Box, Text, Link as ChakraLink } from "@chakra-ui/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui";
-import { PrivacyPolicyModal } from "./PrivacyPolicyModal";
-import { useGetConsents, useSaveConsent } from "@/lib/hooks/useConsent";
-import { s } from "./styles";
-import { hasLocalConsent, setLocalConsent } from "@/lib/consent-constants";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
+import { hasLocalConsent, setLocalConsent } from "@/lib/consent-constants";
+import { useGetConsents, useSaveConsent } from "@/lib/hooks/useConsent";
+import { PrivacyPolicyModal } from "./PrivacyPolicyModal";
+import { s } from "./styles";
 
 export function CookieBanner() {
   const t = useTranslations("cookieBanner");
-  const { isAuthenticated, isLoading: isAuthLoading } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { isAuthenticated } = auth;
   const [isVisible, setIsVisible] = useState(false);
   const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false);
 
@@ -20,14 +23,14 @@ export function CookieBanner() {
   const { mutate: saveConsent, isPending: isSavingConsent } = useSaveConsent();
 
   useEffect(() => {
-    if (isAuthLoading || isLoadingConsents) return;
+    if (!isAuthReady || isLoadingConsents) return;
     if ((consentsData?.length ?? 0) > 0) {
       if (!hasLocalConsent()) setLocalConsent();
       return;
     }
     if (hasLocalConsent()) return;
     setIsVisible(true);
-  }, [isAuthLoading, isLoadingConsents, consentsData]);
+  }, [isAuthReady, isLoadingConsents, consentsData]);
 
   const handleAccept = () => {
     setLocalConsent();

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -8,6 +8,7 @@ export interface AuthContextValue {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  isAuthReady?: boolean;
   login: (_data: LoginInput) => Promise<AuthResponse>;
   register: (_data: RegisterInput) => Promise<RegisterResponse>;
   logout: () => Promise<void>;

--- a/lib/auth-state.ts
+++ b/lib/auth-state.ts
@@ -1,0 +1,3 @@
+export function resolveAuthReady(value: { isAuthReady?: boolean; isLoading: boolean }): boolean {
+  return value.isAuthReady ?? !value.isLoading;
+}

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -22,6 +22,6 @@ export function useAnalyticsSummary(habitId?: string | null) {
     data: isUnauthorized ? null : query.data,
     error: isUnauthorized ? null : query.error,
     isError: isUnauthorized ? false : query.isError,
-    isLoading: !isAuthReady || query.isLoading,
+    isLoading: !isAuthReady || (isAuthorized && query.isPending),
   };
 }

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -9,11 +9,12 @@ export function useAnalyticsSummary(habitId?: string | null) {
   const isAuthReady = resolveAuthReady(auth);
   const { accessToken } = auth;
   const isUnauthorized = !isAuthReady || !accessToken;
+  const isAuthorized = !isUnauthorized;
 
   const query = useQuery<AnalyticsSummary, Error>({
     queryKey: ["analytics", habitId ?? "all"],
     queryFn: () => analyticsService.getSummary(habitId ?? undefined),
-    enabled: isAuthReady && !!accessToken,
+    enabled: isAuthorized,
   });
 
   return {

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -1,16 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
 import { analyticsService } from "@/lib/analytics.service";
 import type { AnalyticsSummary } from "@/types/analytics";
 
 export function useAnalyticsSummary(habitId?: string | null) {
-  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
-  const isUnauthorized = isAuthLoading || !accessToken;
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { accessToken } = auth;
+  const isUnauthorized = !isAuthReady || !accessToken;
 
   const query = useQuery<AnalyticsSummary, Error>({
     queryKey: ["analytics", habitId ?? "all"],
     queryFn: () => analyticsService.getSummary(habitId ?? undefined),
-    enabled: !isAuthLoading && !!accessToken,
+    enabled: isAuthReady && !!accessToken,
   });
 
   return {
@@ -18,6 +21,6 @@ export function useAnalyticsSummary(habitId?: string | null) {
     data: isUnauthorized ? null : query.data,
     error: isUnauthorized ? null : query.error,
     isError: isUnauthorized ? false : query.isError,
-    isLoading: isAuthLoading || query.isLoading,
+    isLoading: !isAuthReady || query.isLoading,
   };
 }

--- a/lib/hooks/useConsent.ts
+++ b/lib/hooks/useConsent.ts
@@ -2,18 +2,21 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { consentService } from "@/lib/consent.service";
 import { toaster } from "@/components/ui/toaster";
-import { useTranslatedError } from "./useTranslatedError";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
+import { useTranslatedError } from "./useTranslatedError";
 
 export function useGetConsents() {
-  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { accessToken } = auth;
 
   return useQuery({
     queryKey: ["consents"],
     queryFn: () => consentService.getConsents(),
     retry: false,
     staleTime: Infinity,
-    enabled: !isAuthLoading && !!accessToken,
+    enabled: isAuthReady && !!accessToken,
   });
 }
 

--- a/lib/hooks/useConsentSync.ts
+++ b/lib/hooks/useConsentSync.ts
@@ -1,10 +1,13 @@
 import { useEffect, useRef } from "react";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
 import { useGetConsents, useSaveConsent } from "./useConsent";
 import { hasLocalConsent } from "@/lib/consent-constants";
 
 export function useConsentSync() {
-  const { isAuthenticated, isLoading: isAuthLoading } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { isAuthenticated } = auth;
   const { data: consentsData, isLoading: isLoadingConsents } = useGetConsents();
   const { mutate: saveConsent } = useSaveConsent({
     onError: () => {
@@ -19,7 +22,7 @@ export function useConsentSync() {
       return;
     }
 
-    if (isAuthLoading || isLoadingConsents) return;
+    if (!isAuthReady || isLoadingConsents) return;
     if (hasSynced.current) return;
     if (!hasLocalConsent()) return;
     if ((consentsData?.length ?? 0) > 0) {
@@ -29,5 +32,5 @@ export function useConsentSync() {
 
     hasSynced.current = true;
     saveConsent();
-  }, [isAuthLoading, isLoadingConsents, isAuthenticated, consentsData, saveConsent]);
+  }, [isAuthReady, isLoadingConsents, isAuthenticated, consentsData, saveConsent]);
 }

--- a/lib/hooks/useHabits.ts
+++ b/lib/hooks/useHabits.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
 import {
   habitService,
   type CreateHabitInput,
@@ -12,17 +13,19 @@ import type { Habit } from "@/types/habits";
 import { useTranslatedError } from "./useTranslatedError";
 
 export function useHabits() {
-  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { accessToken } = auth;
 
   const query = useQuery<Habit[], Error>({
     queryKey: ["habits"],
     queryFn: () => habitService.list(),
-    enabled: !isAuthLoading && !!accessToken,
+    enabled: isAuthReady && !!accessToken,
   });
 
   return {
     ...query,
-    isLoading: isAuthLoading || query.isPending,
+    isLoading: !isAuthReady || query.isLoading,
   };
 }
 

--- a/lib/hooks/useJournal.ts
+++ b/lib/hooks/useJournal.ts
@@ -11,16 +11,17 @@ export function useJournalEntries(date: string) {
   const auth = useAuthContext();
   const isAuthReady = resolveAuthReady(auth);
   const { accessToken } = auth;
+  const isQueryEnabled = isAuthReady && !!accessToken;
 
   const query = useQuery({
     queryKey: ["journal", date],
     queryFn: () => journalService.getEntriesByDate(date),
-    enabled: isAuthReady && !!accessToken,
+    enabled: isQueryEnabled,
   });
 
   return {
     ...query,
-    isLoading: !isAuthReady || query.isPending,
+    isLoading: !isAuthReady || (isQueryEnabled && query.isPending),
   };
 }
 
@@ -28,16 +29,17 @@ export function useJournalHistory() {
   const auth = useAuthContext();
   const isAuthReady = resolveAuthReady(auth);
   const { accessToken } = auth;
+  const isQueryEnabled = isAuthReady && !!accessToken;
 
   const query = useQuery({
     queryKey: ["journal-history"],
     queryFn: () => journalService.listHistory(),
-    enabled: isAuthReady && !!accessToken,
+    enabled: isQueryEnabled,
   });
 
   return {
     ...query,
-    isLoading: !isAuthReady || query.isPending,
+    isLoading: !isAuthReady || (isQueryEnabled && query.isPending),
   };
 }
 

--- a/lib/hooks/useJournal.ts
+++ b/lib/hooks/useJournal.ts
@@ -1,38 +1,43 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
 import { journalService } from "@/lib/journal.service";
 import { toaster } from "@/components/ui/toaster";
 import type { CreateJournalEntryInput, JournalEntry } from "@/types/journal";
 import { useTranslatedError } from "./useTranslatedError";
 
 export function useJournalEntries(date: string) {
-  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { accessToken } = auth;
 
   const query = useQuery({
     queryKey: ["journal", date],
     queryFn: () => journalService.getEntriesByDate(date),
-    enabled: !isAuthLoading && !!accessToken,
+    enabled: isAuthReady && !!accessToken,
   });
 
   return {
     ...query,
-    isLoading: isAuthLoading || query.isPending,
+    isLoading: !isAuthReady || query.isLoading,
   };
 }
 
 export function useJournalHistory() {
-  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { accessToken } = auth;
 
   const query = useQuery({
     queryKey: ["journal-history"],
     queryFn: () => journalService.listHistory(),
-    enabled: !isAuthLoading && !!accessToken,
+    enabled: isAuthReady && !!accessToken,
   });
 
   return {
     ...query,
-    isLoading: isAuthLoading || query.isPending,
+    isLoading: !isAuthReady || query.isLoading,
   };
 }
 

--- a/lib/hooks/useJournal.ts
+++ b/lib/hooks/useJournal.ts
@@ -20,7 +20,7 @@ export function useJournalEntries(date: string) {
 
   return {
     ...query,
-    isLoading: !isAuthReady || query.isLoading,
+    isLoading: !isAuthReady || query.isPending,
   };
 }
 
@@ -37,7 +37,7 @@ export function useJournalHistory() {
 
   return {
     ...query,
-    isLoading: !isAuthReady || query.isLoading,
+    isLoading: !isAuthReady || query.isPending,
   };
 }
 

--- a/lib/hooks/useOnboarding.ts
+++ b/lib/hooks/useOnboarding.ts
@@ -1,13 +1,16 @@
 import { useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
 import { onboardingService } from "@/lib/onboarding.service";
 import type { UpdateOnboardingInput } from "@/types/onboarding";
 
 const LS_KEY_PREFIX = "onboarding_completed";
 
 export function useOnboarding() {
-  const { isAuthenticated, isLoading: isAuthLoading, user } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { isAuthenticated, user } = auth;
   const queryClient = useQueryClient();
 
   const lsKey = user?.id ? `${LS_KEY_PREFIX}_${user.id}` : null;
@@ -20,7 +23,7 @@ export function useOnboarding() {
   const query = useQuery({
     queryKey: onboardingQueryKey,
     queryFn: () => onboardingService.getStatus(),
-    enabled: !isAuthLoading && isAuthenticated && Boolean(user?.id),
+    enabled: isAuthReady && isAuthenticated && Boolean(user?.id),
     staleTime: Infinity,
     retry: false,
   });

--- a/lib/hooks/useProfile.ts
+++ b/lib/hooks/useProfile.ts
@@ -1,23 +1,26 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
 import { userService } from "@/lib/user.service";
 import { toaster } from "@/components/ui/toaster";
 import type { UpdateProfileInput, UserProfile } from "@/types/user";
 import { useTranslatedError } from "./useTranslatedError";
 
 export function useGetProfile() {
-  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { accessToken } = auth;
 
   const query = useQuery({
     queryKey: ["profile"],
     queryFn: () => userService.getMe(),
-    enabled: !isAuthLoading && !!accessToken,
+    enabled: isAuthReady && !!accessToken,
   });
 
   return {
     ...query,
-    isLoading: isAuthLoading || query.isPending,
+    isLoading: !isAuthReady || query.isLoading,
   };
 }
 

--- a/lib/hooks/useWordCloud.ts
+++ b/lib/hooks/useWordCloud.ts
@@ -8,15 +8,16 @@ export function useWordCloud(habitId: string | null) {
   const auth = useAuthContext();
   const isAuthReady = resolveAuthReady(auth);
   const { accessToken } = auth;
+  const isQueryEnabled = isAuthReady && !!accessToken && !!habitId;
 
   const query = useQuery<WordCloudItem[], Error>({
     queryKey: ["word-cloud", habitId],
     queryFn: () => pronunciationService.getWordCloud(habitId!),
-    enabled: isAuthReady && !!accessToken && !!habitId,
+    enabled: isQueryEnabled,
   });
 
   return {
     ...query,
-    isLoading: !isAuthReady || query.isLoading,
+    isLoading: !isAuthReady || (isQueryEnabled && query.isPending),
   };
 }

--- a/lib/hooks/useWordCloud.ts
+++ b/lib/hooks/useWordCloud.ts
@@ -9,9 +9,14 @@ export function useWordCloud(habitId: string | null) {
   const isAuthReady = resolveAuthReady(auth);
   const { accessToken } = auth;
 
-  return useQuery<WordCloudItem[], Error>({
+  const query = useQuery<WordCloudItem[], Error>({
     queryKey: ["word-cloud", habitId],
     queryFn: () => pronunciationService.getWordCloud(habitId!),
     enabled: isAuthReady && !!accessToken && !!habitId,
   });
+
+  return {
+    ...query,
+    isLoading: !isAuthReady || query.isLoading,
+  };
 }

--- a/lib/hooks/useWordCloud.ts
+++ b/lib/hooks/useWordCloud.ts
@@ -1,14 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAuthContext } from "@/lib/auth-context";
+import { resolveAuthReady } from "@/lib/auth-state";
 import { pronunciationService } from "@/lib/pronunciation.service";
 import type { WordCloudItem } from "@/types/pronunciation";
 
 export function useWordCloud(habitId: string | null) {
-  const { isLoading: isAuthLoading, accessToken } = useAuthContext();
+  const auth = useAuthContext();
+  const isAuthReady = resolveAuthReady(auth);
+  const { accessToken } = auth;
 
   return useQuery<WordCloudItem[], Error>({
     queryKey: ["word-cloud", habitId],
     queryFn: () => pronunciationService.getWordCloud(habitId!),
-    enabled: !isAuthLoading && !!accessToken && !!habitId,
+    enabled: isAuthReady && !!accessToken && !!habitId,
   });
 }

--- a/lib/routing-utils.ts
+++ b/lib/routing-utils.ts
@@ -25,7 +25,8 @@ export function resolveLocale(pathname: string): (typeof routing.locales)[number
   );
 }
 
-export function isProtectedRoute(pathname: string): boolean {
+export function isProtectedRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
   return routing.locales.some((locale) =>
     PROTECTED_SEGMENTS.some(
       (segment) =>

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -6,7 +6,7 @@ import { AuthContext } from "@/lib/auth-context";
 import { api } from "@/lib/api-client";
 import { authService } from "@/lib/auth.service";
 import type { AuthResponse, RegisterResponse, LoginInput, RegisterInput, User } from "@/types/auth";
-import { isAuthRoute } from "@/lib/routing-utils";
+import { isAuthRoute, isProtectedRoute } from "@/lib/routing-utils";
 import { logger } from "@/lib/logger";
 
 function hasRefreshTokenCookie(): boolean {
@@ -20,7 +20,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const hasAttemptedRestore = useRef(false);
   const [accessToken, setAccessTokenState] = useState<string | null>(null);
   const [user, setUserState] = useState<User | null>(null);
-  const [isLoading, setIsLoading] = useState(!isCurrentAuthRoute);
+  const [isAuthReady, setIsAuthReady] = useState(isCurrentAuthRoute);
 
   useEffect(() => {
     api.setOnTokenRefreshed((newToken, newUser) => {
@@ -31,51 +31,43 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (isCurrentAuthRoute) {
-      setIsLoading(false);
+      setIsAuthReady(true);
       return;
     }
+
+    const existingToken = api.getToken();
+    const shouldAttemptRestore =
+      Boolean(existingToken) || isProtectedRoute(pathname) || hasRefreshTokenCookie();
+
+    if (!shouldAttemptRestore) {
+      logger.debug("[AuthProvider] skipping session restore on public route", { pathname });
+      setIsAuthReady(true);
+      return;
+    }
+
     if (hasAttemptedRestore.current) return;
     hasAttemptedRestore.current = true;
 
-    const existingToken = api.getToken();
     if (existingToken) {
       setAccessTokenState(existingToken);
-      authService
-        .refresh()
-        .then((data) => {
-          api.setToken(data.token);
-          setAccessTokenState(data.token);
-          setUserState(data.user);
-        })
-        .catch(() => {
-          api.removeToken();
-          setAccessTokenState(null);
-        })
-        .finally(() => {
-          setIsLoading(false);
-        });
-      return;
     }
 
-    const hasRefreshToken = hasRefreshTokenCookie();
-    if (hasRefreshToken) {
-      authService
-        .refresh()
-        .then((data) => {
-          api.setToken(data.token);
-          setAccessTokenState(data.token);
-          setUserState(data.user);
-        })
-        .catch((error) => {
-          logger.debug("[AuthProvider] silent refresh failed", error);
-        })
-        .finally(() => {
-          setIsLoading(false);
-        });
-    } else {
-      setIsLoading(false);
-    }
-  }, [isCurrentAuthRoute]);
+    authService
+      .refresh()
+      .then((data) => {
+        api.setToken(data.token);
+        setAccessTokenState(data.token);
+        setUserState(data.user);
+      })
+      .catch(() => {
+        api.removeToken();
+        setAccessTokenState(null);
+        setUserState(null);
+      })
+      .finally(() => {
+        setIsAuthReady(true);
+      });
+  }, [pathname, isCurrentAuthRoute]);
 
   const login = useCallback(async (data: LoginInput): Promise<AuthResponse> => {
     const response = await authService.login(data);
@@ -113,7 +105,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         accessToken,
         user,
         isAuthenticated: accessToken !== null,
-        isLoading,
+        isLoading: !isAuthReady,
+        isAuthReady,
         login,
         register,
         logout,

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -46,11 +46,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     if (hasAttemptedRestore.current) return;
+    setIsAuthReady(false);
     hasAttemptedRestore.current = true;
-
-    if (existingToken) {
-      setAccessTokenState(existingToken);
-    }
 
     authService
       .refresh()

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -17,7 +17,9 @@ function hasRefreshTokenCookie(): boolean {
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isCurrentAuthRoute = isAuthRoute(pathname);
+  const isCurrentProtectedRoute = isProtectedRoute(pathname);
   const hasAttemptedRestore = useRef(false);
+  const previousIsProtectedRoute = useRef(isCurrentProtectedRoute);
   const [accessToken, setAccessTokenState] = useState<string | null>(null);
   const [user, setUserState] = useState<User | null>(null);
   const [isAuthReady, setIsAuthReady] = useState(isCurrentAuthRoute);
@@ -30,6 +32,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (!previousIsProtectedRoute.current && isCurrentProtectedRoute) {
+      hasAttemptedRestore.current = false;
+    }
+    previousIsProtectedRoute.current = isCurrentProtectedRoute;
+
     if (isCurrentAuthRoute) {
       setIsAuthReady(true);
       return;
@@ -37,7 +44,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const existingToken = api.getToken();
     const shouldAttemptRestore =
-      Boolean(existingToken) || isProtectedRoute(pathname) || hasRefreshTokenCookie();
+      Boolean(existingToken) || isCurrentProtectedRoute || hasRefreshTokenCookie();
 
     if (!shouldAttemptRestore) {
       logger.debug("[AuthProvider] skipping session restore on public route", { pathname });
@@ -64,7 +71,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       .finally(() => {
         setIsAuthReady(true);
       });
-  }, [pathname, isCurrentAuthRoute]);
+  }, [pathname, isCurrentAuthRoute, isCurrentProtectedRoute]);
 
   const login = useCallback(async (data: LoginInput): Promise<AuthResponse> => {
     const response = await authService.login(data);

--- a/tests/unit/lib/auth-context.test.tsx
+++ b/tests/unit/lib/auth-context.test.tsx
@@ -98,30 +98,33 @@ describe("AuthProvider", () => {
       expect(mockApi.setToken).toHaveBeenCalledWith(mockAuthResponse.token);
     });
 
-    it("skips loading block and hydrates user via background refresh when token already in memory", async () => {
+    it("hydrates user after validating the in-memory token via refresh", async () => {
       mockApi.getToken.mockReturnValue("existing-token");
       mockAuthService.refresh.mockResolvedValue(mockAuthResponse);
 
       const { result } = renderHook(() => useAuthContext(), { wrapper });
 
-      expect(result.current.accessToken).toBe("existing-token");
-      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.accessToken).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       await waitFor(() => expect(result.current.user).toEqual(mockAuthResponse.user));
       expect(result.current.accessToken).toBe(mockAuthResponse.token);
+      expect(result.current.isAuthenticated).toBe(true);
 
       mockApi.getToken.mockReturnValue(null);
     });
 
-    it("clears token and auth state if background refresh fails after memory token", async () => {
+    it("keeps auth state cleared if in-memory token validation fails", async () => {
       mockApi.getToken.mockReturnValue("existing-token");
       mockAuthService.refresh.mockRejectedValue(new Error("Session expired"));
 
       const { result } = renderHook(() => useAuthContext(), { wrapper });
 
-      expect(result.current.accessToken).toBe("existing-token");
-      expect(result.current.isAuthenticated).toBe(true);
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.accessToken).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       await waitFor(() => expect(result.current.accessToken).toBeNull());


### PR DESCRIPTION
## Summary
- make auth bootstrap explicit with `isAuthReady` while keeping the existing `isLoading` contract intact
- restore sessions on protected routes after a hard reload even when the refresh cookie is HttpOnly and not readable from client-side JavaScript
- stop protected React Query hooks from showing infinite loading when auth bootstrap has finished but the query remains disabled

## Validation
- `npm run test:unit -- --runInBand`
- `npm run test:integration -- --runInBand`
- `npm run build`
- `npx tsc --noEmit`
- `npx eslint lib/auth-state.ts lib/auth-context.tsx lib/routing-utils.ts providers/AuthProvider.tsx lib/hooks/useHabits.ts lib/hooks/useProfile.ts lib/hooks/useJournal.ts lib/hooks/useAnalytics.ts lib/hooks/useConsent.ts lib/hooks/useWordCloud.ts lib/hooks/useOnboarding.ts lib/hooks/useConsentSync.ts components/CookieBanner/index.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Melhoria no fluxo de prontidão/autenticação para garantir que componentes e hooks apenas executem ações (consentimentos, consultas e sincronizações) quando o estado de autenticação estiver resolvido, aumentando confiabilidade e evitando renderizações prematuras.
* **Tests**
  * Ajustes em testes de autenticação para refletir novo comportamento de inicialização e restauração de sessão (cenários de sucesso e falha).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->